### PR TITLE
Add variables for gross CO2 emissions

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -1,6 +1,11 @@
 - Emissions|{Tier-1 Species}:
     description: Emissions of {Tier-1 Species}
     unit: "{Tier-1 Species}"
+- Gross Emissions|CO2:
+    definition: Gross emissions of carbon dioxide (CO2), not accounting for negative
+      emissions from bioenergy with CCS (BECCS) or agriculture, forestry
+      and other land use (AFOLU)
+    unit: Mt CO2/yr
 
 - Emissions|{Tier-2 Species}|AFOLU:
     description: Emissions of {Tier-2 Species} from agriculture, forestry
@@ -40,11 +45,22 @@
       including emissions from international bunkers, net of negative emissions from
       bioenergy with CCS (BECCS) in these sectors
     unit: "{Tier-3 Species}"
+- Gross Emissions|CO2|Energy and Industrial Processes:
+    definition: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
+      (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
+      including emissions from international bunkers, not accounting for
+      negative emissions from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 
 - Emissions|{Tier-2 Species}|Energy:
     description: Emissions of {Tier-2 Species} from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B)
     unit: "{Tier-2 Species}"
+- Gross Emissions|CO2|Energy:
+    definition: Gross emissions of carbon dioxide (CO2) from energy use,
+      including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for
+      negative emissions from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 - Emissions|{Tier-2 Species}|Energy|Supply:
     description: Emissions of {Tier-2 Species} from fuel combustion and fugitive emissions
       from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
@@ -53,17 +69,42 @@
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
       transport and storage (IPCC category 1C)
     unit: "{Tier-2 Species}"
+- Gross Emissions|CO2|Energy|Supply:
+    definition: Gross emissions of carbon dioxide (CO2) from fuel combustion and fugitive emissions
+      from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
+      other energy conversion (e.g., refineries, synfuel production, solid fuel processing,
+      IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei),
+      fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
+      transport and storage (IPCC category 1C), not accounting for negative emissions
+      from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|Electricity:
     description: Emissions of carbon dioxide (CO2) for electricity generation
+    unit: Mt CO2/yr
+- Gross Emissions|CO2|Energy|Supply|Electricity:
+    description: Gross emissions of carbon dioxide (CO2) for electricity generation,
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|{Secondary Fuel}:
     description: Emissions of carbon dioxide (CO2) for production of {Secondary Fuel}
     unit: Mt CO2/yr
+- Gross Emissions|CO2|Energy|Supply|{Secondary Fuel}:
+    description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel},
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
+    unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|Autoproduction:
     description: Emissions of carbon dioxide (CO2) for own-use energy supply
     unit: Mt CO2/yr
+- Gross Emissions|CO2|Energy|Supply|Autoproduction:
+    description: Gross emissions of carbon dioxide (CO2) for own-use energy supply,
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
+    unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|Other:
     description: Emissions of carbon dioxide (CO2) for other categories of energy supply
+    unit: Mt CO2/yr
+- Gross Emissions|CO2|Energy|Supply|Other:
+    description: Gross emissions of carbon dioxide (CO2) for other categories of energy supply,
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
 
 - Emissions|{Tier-2 Species}|Energy|Demand:
@@ -73,9 +114,20 @@
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
       net of negative emissions incl. demand-side use of bioenergy with CCS (BECCS)
     unit: "{Tier-2 Species}"
+- Gross Emissions|CO2|Energy|Demand:
+    description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
+      residential, commercial, institutional sectors and agriculture, forestry,
+      fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and transportation sector
+      (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 - Emissions|{Tier-2 Species}|Energy|Demand|Industry:
     description: Emissions of {Tier-2 Species} from fuel combustion in industry (IPCC category 1A2)
     unit: "{Tier-2 Species}"
+- Gross Emissions|CO2|Energy|Demand|Industry:
+    description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
+     not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
     unit: Mt CO2/yr
@@ -107,6 +159,10 @@
     description: Emissions of {Tier-3 Species} from industrial processes,
       net of negative emissions using CCS
     unit: "{Tier-3 Species}"
+- Gross Emissions|CO2|Industrial Processes:
+    description: Gross emissions of carbon dioxide (CO2) from industrial processes
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+    unit: Mt CO2/yr
 - Emissions|{Tier-3 Species}|Industrial Processes|{Non-Energy Sector}:
     description: Emissions of {Tier-3 Species} from industrial processes
       in the {Non-Energy Sector}


### PR DESCRIPTION
This PR adds the variables for gross CO2 emissions (only counting the positive emissions, not any CO2 removal in a sector) developed in the NAVIGATE project.

This variable is the complement to the variables "Carbon Capture" with fossil fuels (to be added in a subsequent PR).

For discussion: do we add the variable tree related to carbon capture and gross-emissions from NAVIGATE directly, or are there any changes that should be made as a clean-up or for consistency?