### PR TITLE
Harmonize country mappings

### DIFF
--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -146,10 +146,9 @@
         Democratic Republic of the Congo, Djibouti, Egypt, Equatorial Guinea, Eritrea,
         Ethiopia, Gabon, Gambia, Ghana, Guinea, Guinea-Bissau, Kenya, Lesotho, Liberia,
         Libya, Madagascar, Malawi, Mali, Mauritania, Mauritius, Mayotte, Morocco,
-        Mozambique, Namibia, Niger, Nigeria, Palestine, Rwanda, Réunion,
-        Sao Tome and Principe, Senegal, Sierra Leone, Somalia, South Africa,
-        South Sudan, Sudan, Eswatini, Togo, Tunisia, Uganda, Tanzania, Western Sahara,
-        Zambia, Zimbabwe
+        Mozambique, Namibia, Niger, Nigeria, Rwanda, Réunion, Sao Tome and Principe,
+        Senegal, Sierra Leone, Somalia, South Africa, South Sudan, Sudan, Eswatini,
+        Togo, Tunisia, Uganda, Tanzania, Western Sahara, Zambia, Zimbabwe
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - China+ (R10):
@@ -181,8 +180,8 @@
   - Middle East (R10):
       description: Middle East
       ar6: R10MIDDLE_EAST
-      countries: Bahrain, Iraq, Iran, Israel, Jordan, Kuwait, Lebanon, Oman, Qatar,
-        Saudi Arabia, Syria, United Arab Emirates, Yemen
+      countries: Bahrain, Iraq, Iran, Israel, Jordan, Kuwait, Lebanon, Oman, Palestine,
+        Qatar, Saudi Arabia, Syria, United Arab Emirates, Yemen
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - North America (R10):

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -194,12 +194,12 @@
       countries: Australia, Japan, New Caledonia, New Zealand, Samoa, Solomon Islands,
         Vanuatu
   - Reforming Economies (R10):
-      description: Former Soviet Union
+      description: Former Soviet Union countries not included in Europe
       ar6: R10REF_ECON
       countries: Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
         Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
   - Rest of Asia (R10):
-      description: Other countries of Asia not included in China+ or India+
+      description: Other countries of Asia not included in China+, India+ or Reforming Economies
       ar6: R10REST_ASIA
       countries: Brunei Darussalam, Fiji, French Polynesia, Indonesia, Malaysia,
         Micronesia, New Caledonia, Papua New Guinea, Philippines, South Korea,

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -154,8 +154,8 @@
   - China+ (R10):
       description: Centrally-planned Asia, primarily China.
       ar6: R10CHINA+
-      countries: China, Cambodia, Hong Kong, Laos, Macao, Mongolia, North Korea,
-        Viet Nam
+      countries: China, Cambodia, Hong Kong, Laos, Macao, Mongolia, Myanmar,
+        North Korea, Viet Nam
   - Europe (R10):
       description: Europe (including Turkey).
       ar6: R10EUROPE
@@ -202,7 +202,7 @@
       description: Other countries of Asia not included in China+ or India+.
       ar6: R10REST_ASIA
       countries: Brunei Darussalam, Fiji, French Polynesia, Indonesia, Malaysia,
-        Micronesia, Myanmar, New Caledonia, Papua New Guinea, Philippines, South Korea,
+        Micronesia, New Caledonia, Papua New Guinea, Philippines, South Korea,
         Samoa, Singapore, Solomon Islands, Taiwan, Thailand, Timor-Leste, Vanuatu
   - Other (R10):
       description: Rest of the World, to be used only if a match with the R10 regions

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -147,19 +147,21 @@
         Libya, Madagascar, Malawi, Mali, Mauritania, Mauritius, Mayotte, Morocco,
         Mozambique, Namibia, Niger, Nigeria, Palestine, Rwanda, Réunion, Senegal,
         Sierra Leone, Somalia, South Africa, South Sudan, Sudan, Eswatini, Togo,
-        Tunisia, Uganda, Tanzania, Western Sahara, Zambia, Zimbabwe
+        Tunisia, Uganda, Tanzania, Western Sahara, Zambia, Zimbabwe, Sao Tome and Principe
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - China+ (R10):
       description: Centrally-planned Asia, primarily China.
       ar6: R10CHINA+
-      countries: China, Cambodia, Hong Kong, Laos, Mongolia, North Korea, Viet Nam
+      countries: China, Cambodia, Hong Kong, Laos, Mongolia, North Korea
   - Europe (R10):
       description: Europe (including Turkey).
       ar6: R10EUROPE
       countries: Austria, Belgium, Croatia, Denmark, France, Finland, Spain, Sweden,
         Germany, Greece, Iceland, Ireland, Italy, Luxembourg, Netherlands, Norway,
-        Portugal, Switzerland, Turkey, United Kingdom
+        Portugal, Switzerland, Turkey, United Kingdom, Bulgaria, Bosnia and Herzegovina,
+        Cyprus, Czech Republic, Hungary, North Macedonia, Malta, Poland, Romania, Serbia,
+        Slovakia, Slovenia, Estonia, Lithuania, Latvia
   - India+ (R10):
       description: South Asia, primarily India.
       ar6: R10INDIA+
@@ -172,7 +174,7 @@
         Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador, Guadeloupe,
         Guatemala, Guyana, Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua,
         Panama, Paraguay, Peru, Puerto Rico, Suriname, Trinidad and Tobago, Uruguay,
-        Venezuela
+        Venezuela, Grenada, Saint Lucia, Saint Vincent and the Grenadines
   - Middle East (R10):
       description: Middle East.
       ar6: R10MIDDLE_EAST
@@ -198,7 +200,8 @@
       description: Other countries of Asia not included in China+ or India+.
       ar6: R10REST_ASIA
       countries: Afghanistan, Bangladesh, Bhutan, Fiji, Maldives, Nepal, Pakistan,
-        South Korea, Sri Lanka, Cambodia, Laos, Mongolia, Viet Nam
+        South Korea, Sri Lanka, Cambodia, Laos, Mongolia, Viet Nam, Papua New Guinea,
+        Tonga, , Brunei Darussalam, Indonesia, Malaysia, Phillipines, Singapore, Thailand
   - Other (R10):
       description: Rest of the World, to be used only if a match with the R10 regions
         can otherwise not be achieved.

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -28,9 +28,9 @@
       ssp: R5.2ASIA
       countries: Afghanistan, Bangladesh, Bhutan, Brunei Darussalam, Cambodia, China,
         Fiji, French Polynesia, Hong Kong, India, Indonesia, Laos, Macao, Malaysia,
-        Maldives, Micronesia, Mongolia, Myanmar, Nepal, New Caledonia, Pakistan,
-        Papua New Guinea, Philippines, South Korea, Samoa, Singapore, Solomon Islands,
-        Sri Lanka, Taiwan, Thailand, Timor-Leste, Vanuatu, Viet Nam
+        Maldives, Micronesia, Mongolia, Myanmar, Nepal, New Caledonia, North Korea,
+        Pakistan, Papua New Guinea, Philippines, South Korea, Samoa, Singapore,
+        Solomon Islands, Sri Lanka, Taiwan, Thailand, Timor-Leste, Vanuatu, Viet Nam
   - Middle East & Africa (R5):
       description: Countries of the Middle East and Africa.
       ar6: R5MAF
@@ -99,9 +99,9 @@
       navigate: R9OTHERASIA
       countries: Afghanistan, Bangladesh, Bhutan, Brunei Darussalam, Cambodia, Fiji,
         French Polynesia, Indonesia, Laos, Malaysia, Maldives, Micronesia, Mongolia,
-        Myanmar, Nepal, New Caledonia, Pakistan, Papua New Guinea, Philippines,
-        South Korea, Samoa, Singapore, Solomon Islands, Sri Lanka, Taiwan, Thailand,
-        Timor-Leste, Vanuatu, Viet Nam
+        Myanmar, Nepal, New Caledonia, North Korea, Pakistan, Papua New Guinea,
+        Philippines, South Korea, Samoa, Singapore, Solomon Islands, Sri Lanka, Taiwan,
+        Thailand, Timor-Leste, Vanuatu, Viet Nam
   - Reforming Economies (R9):
       description: Countries from the Reforming Economies of the Former Soviet Union.
       navigate: R9REF
@@ -153,7 +153,8 @@
   - China+ (R10):
       description: Centrally-planned Asia, primarily China.
       ar6: R10CHINA+
-      countries: China, Cambodia, Hong Kong, Laos, Mongolia, North Korea
+      countries: China, Cambodia, Hong Kong, Laos, Macao, Mongolia, North Korea,
+        Viet Nam
   - Europe (R10):
       description: Europe (including Turkey).
       ar6: R10EUROPE
@@ -199,9 +200,9 @@
   - Rest of Asia (R10):
       description: Other countries of Asia not included in China+ or India+.
       ar6: R10REST_ASIA
-      countries: Afghanistan, Bangladesh, Bhutan, Fiji, Maldives, Nepal, Pakistan,
-        South Korea, Sri Lanka, Cambodia, Laos, Mongolia, Viet Nam, Papua New Guinea,
-        Tonga, , Brunei Darussalam, Indonesia, Malaysia, Phillipines, Singapore, Thailand
+      countries: Brunei Darussalam, Fiji, French Polynesia, Indonesia, Malaysia,
+        Micronesia, Myanmar, New Caledonia, Papua New Guinea, Philippines, South Korea,
+        Samoa, Singapore, Solomon Islands, Taiwan, Thailand, Timor-Leste, Vanuatu
   - Other (R10):
       description: Rest of the World, to be used only if a match with the R10 regions
         can otherwise not be achieved.

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -42,8 +42,8 @@
         Guinea-Bissau, Iran, Iraq, Israel, Jordan, Kenya, Kuwait, Lebanon, Lesotho,
         Liberia, Libya, Madagascar, Malawi, Mali, Mauritania, Mauritius, Mayotte,
         Morocco, Mozambique, Namibia, Niger, Nigeria, Palestine, Oman, Qatar, Rwanda,
-        Réunion, Saudi Arabia, Senegal, Sierra Leone, Somalia, South Africa,
-        South Sudan, Sudan, Eswatini, Syria, Togo, Tunisia, Uganda,
+        Réunion, Sao Tome and Principe, Saudi Arabia, Senegal, Sierra Leone, Somalia,
+        South Africa, South Sudan, Sudan, Eswatini, Syria, Togo, Tunisia, Uganda,
         United Arab Emirates, Tanzania, Western Sahara, Yemen, Zambia, Zimbabwe
   - Latin America (R5):
       description: Latin and South American countries.
@@ -113,12 +113,12 @@
       countries: Algeria, Angola, Bahrain, Benin, Botswana, Burkina Faso, Burundi,
         Cameroon, Cabo Verde, Central African Republic, Chad, Comoros, Congo,
         Côte d'Ivoire, Democratic Republic of the Congo, Djibouti, Egypt,
-        Equatorial Guinea, Eritrea, Ethiopia, Gabon, Gambia, Ghana, Guinea,
+        Equatorial Guinea, Eritrea, Eswatini, Ethiopia, Gabon, Gambia, Ghana, Guinea,
         Guinea-Bissau, Iran, Iraq, Israel, Jordan, Kenya, Kuwait, Lebanon, Lesotho,
         Liberia, Libya, Madagascar, Malawi, Mali, Mauritania, Mauritius, Mayotte,
         Morocco, Mozambique, Namibia, Niger, Nigeria, Palestine, Oman, Qatar, Rwanda,
-        Réunion, Saudi Arabia, Senegal, Sierra Leone, Somalia, South Africa,
-        South Sudan, Sudan, Eswatini, Syria, Togo, Tunisia, Uganda,
+        Réunion, Sao Tome and Principe, Saudi Arabia, Senegal, Sierra Leone, Somalia,
+        South Africa, South Sudan, Sudan, Syria, Togo, Tunisia, Uganda,
         United Arab Emirates, Tanzania, Western Sahara, Yemen, Zambia, Zimbabwe
   - Latin America (R9):
       description: Latin and South American countries.
@@ -145,9 +145,10 @@
         Democratic Republic of the Congo, Djibouti, Egypt, Equatorial Guinea, Eritrea,
         Ethiopia, Gabon, Gambia, Ghana, Guinea, Guinea-Bissau, Kenya, Lesotho, Liberia,
         Libya, Madagascar, Malawi, Mali, Mauritania, Mauritius, Mayotte, Morocco,
-        Mozambique, Namibia, Niger, Nigeria, Palestine, Rwanda, Réunion, Senegal,
-        Sierra Leone, Somalia, South Africa, South Sudan, Sudan, Eswatini, Togo,
-        Tunisia, Uganda, Tanzania, Western Sahara, Zambia, Zimbabwe, Sao Tome and Principe
+        Mozambique, Namibia, Niger, Nigeria, Palestine, Rwanda, Réunion,
+        Sao Tome and Principe, Senegal, Sierra Leone, Somalia, South Africa,
+        South Sudan, Sudan, Eswatini, Togo, Tunisia, Uganda, Tanzania, Western Sahara,
+        Zambia, Zimbabwe
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - China+ (R10):
@@ -158,11 +159,11 @@
   - Europe (R10):
       description: Europe (including Turkey).
       ar6: R10EUROPE
-      countries: Austria, Belgium, Croatia, Denmark, France, Finland, Spain, Sweden,
-        Germany, Greece, Iceland, Ireland, Italy, Luxembourg, Netherlands, Norway,
-        Portugal, Switzerland, Turkey, United Kingdom, Bulgaria, Bosnia and Herzegovina,
-        Cyprus, Czech Republic, Hungary, North Macedonia, Malta, Poland, Romania, Serbia,
-        Slovakia, Slovenia, Estonia, Lithuania, Latvia
+      countries: Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus,
+        Czech Republic, Denmark, Estonia, France, Finland, Germany, Greece, Hungary,
+        Iceland, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Montenegro,
+        Netherlands, North Macedonia, Norway, Portugal, Switzerland, Poland, Romania,
+        Serbia, Slovakia, Slovenia, Spain, Sweden, Turkey, United Kingdom
   - India+ (R10):
       description: South Asia, primarily India.
       ar6: R10INDIA+
@@ -172,10 +173,10 @@
       description: Latin America and the Caribbean.
       ar6: R10LATIN_AM
       countries: Argentina, Bahamas, Barbados, Belize, Bolivia, Brazil, Chile, Colombia,
-        Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador, Guadeloupe,
+        Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador, Grenada, Guadeloupe,
         Guatemala, Guyana, Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua,
-        Panama, Paraguay, Peru, Puerto Rico, Suriname, Trinidad and Tobago, Uruguay,
-        Venezuela, Grenada, Saint Lucia, Saint Vincent and the Grenadines
+        Panama, Paraguay, Peru, Puerto Rico, Saint Lucia, Suriname, Trinidad and Tobago,
+        Uruguay, Venezuela
   - Middle East (R10):
       description: Middle East.
       ar6: R10MIDDLE_EAST

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -32,7 +32,7 @@
         Pakistan, Papua New Guinea, Philippines, South Korea, Samoa, Singapore,
         Solomon Islands, Sri Lanka, Taiwan, Thailand, Timor-Leste, Vanuatu, Viet Nam
   - Middle East & Africa (R5):
-      description: Countries of the Middle East and Africa.
+      description: Countries of the Middle East and Africa
       ar6: R5MAF
       ssp: R5.2MAF
       countries: Algeria, Angola, Bahrain, Benin, Botswana, Burkina Faso, Burundi,
@@ -46,7 +46,7 @@
         South Africa, South Sudan, Sudan, Eswatini, Syria, Togo, Tunisia, Uganda,
         United Arab Emirates, Tanzania, Western Sahara, Yemen, Zambia, Zimbabwe
   - Latin America (R5):
-      description: Latin and South American countries.
+      description: Latin and South American countries
       ar6: R5LAM
       ssp: R5.2LAM
       countries: Argentina, Aruba, Bahamas, Barbados, Belize, Bolivia, Brazil, Chile,
@@ -74,29 +74,29 @@
       note: Depending on the spatial resolution, reporting by some models may differ
         from the current list of EU27 members (2023).
   - USA (R9):
-      description: United States of America.
+      description: United States of America
       navigate: R9USA
       countries: United States
       note: Depending on the spatial resolution, some models report Canada as part of
         the USA region.
   - Other OECD (R9):
-      description: Other OECD countries.
+      description: Other OECD (membership status 1990) and EU canditate countries
       navigate: R9OTHEROECD
       countries: Albania, Australia, Bosnia and Herzegovina, Canada, Guam, Iceland,
         Japan, Montenegro, New Zealand, North Macedonia, Norway, Puerto Rico, Serbia,
         United Kingdom, Switzerland, Turkey
       note: This region is defined as 'OECD & EU (R5)' excluding EU and USA
   - China (R9):
-      description: China.
+      description: China
       navigate: R9CHINA
       countries: China, Hong Kong, Macao
   - India (R9):
-      description: India.
+      description: India
       navigate: R9INDIA
       countries: India
   - Other Asia (R9):
       description: The region includes Asian countries with the exception of China,
-        India, the Middle East, Japan and Former Soviet Union states.
+        India, the Middle East, Japan and Former Soviet Union states
       navigate: R9OTHERASIA
       countries: Afghanistan, Bangladesh, Bhutan, Brunei Darussalam, Cambodia, Fiji,
         French Polynesia, Indonesia, Laos, Malaysia, Maldives, Micronesia, Mongolia,
@@ -104,12 +104,12 @@
         Philippines, South Korea, Samoa, Singapore, Solomon Islands, Sri Lanka, Taiwan,
         Thailand, Timor-Leste, Vanuatu, Viet Nam
   - Reforming Economies (R9):
-      description: Countries from the Reforming Economies of the Former Soviet Union.
+      description: Countries from the Reforming Economies of the Former Soviet Union
       navigate: R9REF
       countries: Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
         Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
   - Middle East & Africa (R9):
-      description: Countries of the Middle East and Africa.
+      description: Countries of the Middle East and Africa
       navigate: R9MAF
       countries: Algeria, Angola, Bahrain, Benin, Botswana, Burkina Faso, Burundi,
         Cameroon, Cabo Verde, Central African Republic, Chad, Comoros, Congo,
@@ -122,7 +122,7 @@
         South Africa, South Sudan, Sudan, Syria, Togo, Tunisia, Uganda,
         United Arab Emirates, Tanzania, Western Sahara, Yemen, Zambia, Zimbabwe
   - Latin America (R9):
-      description: Latin and South American countries.
+      description: Latin and South American countries
       navigate: R9LAM
       countries: Argentina, Aruba, Bahamas, Barbados, Belize, Bolivia, Brazil, Chile,
         Colombia, Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador,
@@ -131,7 +131,7 @@
         Trinidad and Tobago, United States Virgin Islands, Uruguay, Venezuela
   - Other (R9):
       description: Rest of the World, used only if a match with the R9 regions can
-        otherwise not be achieved.
+        otherwise not be achieved
       navigate: R9OWO
 
 # The R10 definitions were introduced by the LIMITS project
@@ -139,7 +139,7 @@
 # (grant agreement no. 282846)
 - R10:
   - Africa (R10):
-      description: Africa.
+      description: Africa
       ar6: R10AFRICA
       countries: Algeria, Angola, Benin, Botswana, Burkina Faso, Burundi, Cameroon,
         Cabo Verde, Central African Republic, Chad, Comoros, Congo, Côte d'Ivoire,
@@ -153,12 +153,12 @@
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - China+ (R10):
-      description: Centrally-planned Asia, primarily China.
+      description: Centrally-planned Asia, primarily China
       ar6: R10CHINA+
       countries: China, Cambodia, Hong Kong, Laos, Macao, Mongolia, Myanmar,
         North Korea, Viet Nam
   - Europe (R10):
-      description: Europe (including Turkey).
+      description: Europe (including Turkey)
       ar6: R10EUROPE
       countries: Austria, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus,
         Czech Republic, Denmark, Estonia, France, Finland, Germany, Greece, Hungary,
@@ -166,12 +166,12 @@
         Netherlands, North Macedonia, Norway, Portugal, Switzerland, Poland, Romania,
         Serbia, Slovakia, Slovenia, Spain, Sweden, Turkey, United Kingdom
   - India+ (R10):
-      description: South Asia, primarily India.
+      description: South Asia, primarily India
       ar6: R10INDIA+
       countries: India, Afghanistan, Bangladesh, Bhutan, Maldives, Nepal, Pakistan,
         Sri Lanka
   - Latin America (R10):
-      description: Latin America and the Caribbean.
+      description: Latin America and the Caribbean
       ar6: R10LATIN_AM
       countries: Argentina, Bahamas, Barbados, Belize, Bolivia, Brazil, Chile, Colombia,
         Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador, Grenada, Guadeloupe,
@@ -179,14 +179,14 @@
         Panama, Paraguay, Peru, Puerto Rico, Saint Lucia, Suriname, Trinidad and Tobago,
         Uruguay, Venezuela
   - Middle East (R10):
-      description: Middle East.
+      description: Middle East
       ar6: R10MIDDLE_EAST
       countries: Bahrain, Iraq, Iran, Israel, Jordan, Kuwait, Lebanon, Oman, Qatar,
         Saudi Arabia, Syria, United Arab Emirates, Yemen
       note: Depending on the spatial resolution, some models report Northern Africa
         as part of the Middle East region.
   - North America (R10):
-      description: United States and Canada.
+      description: United States and Canada
       ar6: R10NORTH_AM
       countries: Canada, Guam, United States
   - Pacific OECD (R10):
@@ -195,17 +195,17 @@
       countries: Australia, Japan, New Caledonia, New Zealand, Samoa, Solomon Islands,
         Vanuatu
   - Reforming Economies (R10):
-      description: Former Soviet Union.
+      description: Former Soviet Union
       ar6: R10REF_ECON
       countries: Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
         Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
   - Rest of Asia (R10):
-      description: Other countries of Asia not included in China+ or India+.
+      description: Other countries of Asia not included in China+ or India+
       ar6: R10REST_ASIA
       countries: Brunei Darussalam, Fiji, French Polynesia, Indonesia, Malaysia,
         Micronesia, New Caledonia, Papua New Guinea, Philippines, South Korea,
         Samoa, Singapore, Solomon Islands, Taiwan, Thailand, Timor-Leste, Vanuatu
   - Other (R10):
       description: Rest of the World, to be used only if a match with the R10 regions
-        can otherwise not be achieved.
+        can otherwise not be achieved
       ar6: R10ROWO

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -189,17 +189,16 @@
       ar6: R10NORTH_AM
       countries: Canada, Guam, United States
   - Pacific OECD (R10):
-      description: Pacific OECD (membership status 1990)
+      description: Pacific OECD (membership status 1990) including Pacific islands
       ar6: R10PAC_OECD
-      countries: Australia, Japan, New Caledonia, New Zealand, Samoa, Solomon Islands,
-        Vanuatu
+      countries: Australia, Japan, New Zealand
   - Reforming Economies (R10):
       description: Former Soviet Union countries not included in Europe
       ar6: R10REF_ECON
       countries: Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
         Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
   - Rest of Asia (R10):
-      description: Other countries of Asia not included in China+, India+ or Reforming Economies
+      description: Asia not included in China+, India+ or Reforming Economies
       ar6: R10REST_ASIA
       countries: Brunei Darussalam, Fiji, French Polynesia, Indonesia, Malaysia,
         Micronesia, New Caledonia, Papua New Guinea, Philippines, South Korea,

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -6,7 +6,7 @@
 # https://data.ece.iiasa.ac.at/ar6-scenario-submission/#/about
 - R5:
   - OECD & EU (R5):
-      description: OECD 90 and EU member states and candidates
+      description: OECD (membership status 1990) and EU member states and candidates
       ar6: R5OECD90+EU
       ssp: R5.2OECD
       countries: Albania, Australia, Austria, Belgium, Bosnia and Herzegovina, Bulgaria,
@@ -65,7 +65,7 @@
 # (grant agreement no. 821124)
 - R9:
   - European Union (R9):
-      description: European Union.
+      description: European Union (membership status 2023)
       navigate: R9EU
       countries: Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
         Finland, France, Germany, Greece, Hungary, Ireland, Italy, Latvia, Lithuania,
@@ -85,6 +85,7 @@
       countries: Albania, Australia, Bosnia and Herzegovina, Canada, Guam, Iceland,
         Japan, Montenegro, New Zealand, North Macedonia, Norway, Puerto Rico, Serbia,
         United Kingdom, Switzerland, Turkey
+      note: This region is defined as 'OECD & EU (R5)' excluding EU and USA
   - China (R9):
       description: China.
       navigate: R9CHINA
@@ -189,7 +190,7 @@
       ar6: R10NORTH_AM
       countries: Canada, Guam, United States
   - Pacific OECD (R10):
-      description: Pacific OECD.
+      description: Pacific OECD (membership status 1990)
       ar6: R10PAC_OECD
       countries: Australia, Japan, New Caledonia, New Zealand, Samoa, Solomon Islands,
         Vanuatu


### PR DESCRIPTION
This PR re-implements the region-clean-up (#13), ensuring consistency across R5, R9 and R10 country mappings.

The following design choices were made:
- The Baltic States are part of Europe/EU
- The R9 regions *India* and *China* should include only those countries
- The R10 Region *India+* and *China+* should include neighboring countries that are similar, i.e., on the Indian sub-continent or fit the description "Centrally-planned Asia" (and are close to China)

Of course, these mappings are only a guidance, because actual model implementations will only be an imperfect approximation to these mappings. 