### PR TITLE
Add variables for electricity generation

### DIFF
--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -13,7 +13,7 @@
 
 - Secondary Energy|Electricity|Non-Biomass Renewables:
     definition: Net electricity generation from hydro, wind, solar, geothermal, ocean,
-      and other renewable sources excluding biomass.
+      and other renewable sources excluding biomass
     unit: EJ/yr
 - Secondary Energy|Electricity|{Non-Biomass Renewables}:
     description: Net electricity generation from {Non-Biomass Renewables}
@@ -29,14 +29,6 @@
     definition: Net electricity generation from ammonia
     unit: EJ/yr
 
-- Secondary Energy|Electricity|Fossil:
-    description: Net electricity generation from fossil fuels including coal,
-      natural gas and conventional/unconventional oil
-    unit: EJ/yr
-- Secondary Energy|Electricity|Fossil|{CCS}:
-    description: Net electricity generation from fossil fuels including coal,
-      natural gas and conventional/unconventional oil {CCS}
-    unit: EJ/yr
 - Secondary Energy|Electricity|{Primary Fossil Fuel}:
     description: Net electricity generation from {Primary Fossil Fuel}
     unit: EJ/yr

--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -22,9 +22,11 @@
 - Secondary Energy|Electricity|Nuclear:
     description: Net electricity generation from nuclear power
     unit: EJ/yr
-
 - Secondary Energy|Electricity|Hydrogen:
     definition: Net electricity generation from hydrogen
+    unit: EJ/yr
+- Secondary Energy|Electricity|Ammonia:
+    definition: Net electricity generation from ammonia
     unit: EJ/yr
 
 - Secondary Energy|Electricity|Fossil:

--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -1,0 +1,43 @@
+- Secondary Energy|Electricity:
+    definition: Total net electricity generation
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Biomass:
+    definition: Net electricity generation from purpose-grown bioenergy crops, crop and
+      forestry residue, municipal solid waste bioenergy and traditional biomass
+    unit: EJ/yr
+- Secondary Energy|Electricity|Biomass|{CCS}:
+    definition: Net electricity generation from purpose-grown bioenergy crops, crop and
+      forestry residue, municipal solid waste bioenergy and traditional biomass {CCS}
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Non-Biomass Renewables:
+    definition: Net electricity generation from hydro, wind, solar, geothermal, ocean,
+      and other renewable sources excluding biomass.
+    unit: EJ/yr
+- Secondary Energy|Electricity|{Non-Biomass Renewables}:
+    description: Net electricity generation from {Non-Biomass Renewables}
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Nuclear:
+    description: Net electricity generation from nuclear power
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Hydrogen:
+    definition: Net electricity generation from hydrogen
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Fossil:
+    description: Net electricity generation from fossil fuels including coal,
+      natural gas and conventional/unconventional oil
+    unit: EJ/yr
+- Secondary Energy|Electricity|Fossil|{CCS}:
+    description: Net electricity generation from fossil fuels including coal,
+      natural gas and conventional/unconventional oil {CCS}
+    unit: EJ/yr
+- Secondary Energy|Electricity|{Primary Fossil Fuel}:
+    description:  Net electricity generation from {Primary Fossil Fuel}
+    unit: EJ/yr
+- Secondary Energy|Electricity|{Primary Fossil Fuel}|{CCS}:
+    description:  Net electricity generation from {Primary Fossil Fuel} {CCS}
+    unit: EJ/yr

--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -38,8 +38,12 @@
       natural gas and conventional/unconventional oil {CCS}
     unit: EJ/yr
 - Secondary Energy|Electricity|{Primary Fossil Fuel}:
-    description:  Net electricity generation from {Primary Fossil Fuel}
+    description: Net electricity generation from {Primary Fossil Fuel}
     unit: EJ/yr
 - Secondary Energy|Electricity|{Primary Fossil Fuel}|{CCS}:
-    description:  Net electricity generation from {Primary Fossil Fuel} {CCS}
+    description: Net electricity generation from {Primary Fossil Fuel} {CCS}
+    unit: EJ/yr
+
+- Secondary Energy|Electricity|Other:
+    description: Net electricity generation from sources that do not fit any other category
     unit: EJ/yr

--- a/definitions/variable/energy/tag_non_biomass_renewables.yaml
+++ b/definitions/variable/energy/tag_non_biomass_renewables.yaml
@@ -11,6 +11,14 @@
         description: residential rooftop photovoltaics (PV)
     - Solar|PV|Commercial:
         description: commercial rooftop photovoltaics (PV)
+    - Solar|PV|Open Land:
+        description: photovoltaics (PV) on open land (no mixed use)
+    - Solar|PV|Agri-PV:
+        description: photovoltaics (PV) on agricultural land (mixed use)
+    - Solar|PV|Floating:
+        description: photovoltaics (PV) on water
+    - Solar|PV|Other:
+        description: other types of photovoltaics (PV)
     - Wind:
         description: wind power
     - Wind|Onshore:

--- a/definitions/variable/energy/tag_non_biomass_renewables.yaml
+++ b/definitions/variable/energy/tag_non_biomass_renewables.yaml
@@ -3,8 +3,20 @@
         description: hydropower
     - Solar:
         description: solar energy
+    - Solar|CSP:
+        description: utility-scale concentrated solar power (CSP)
+    - Solar|PV:
+        description: photovoltaics (PV)
+    - Solar|PV|Residential:
+        description: residential rooftop photovoltaics (PV)
+    - Solar|PV|Commercial:
+        description: commercial rooftop photovoltaics (PV)
     - Wind:
         description: wind power
+    - Wind|Onshore:
+        description: onshore wind power
+    - Wind|Offshore:
+        description: offshore wind power
     - Geothermal:
         description: geothermal sources
     - Ocean:


### PR DESCRIPTION
This PR introduces the variable tree for `Secondary Energy|Electricity` based on the ENGAGE and NAVIGATE projects.

A few observations:
- PV is separated into residential-rooftop and commercial-rooftop. Should we add a sub-category for utility-scale "Open Land"? And "Floating"?
- ENGAGE has a variable for electricity generation from ammonia, but NAVIGATE does not. Should we add it here?
- ENGAGE and NAVIGATE have variables for Curtailment, Storage, Storage Losses and Transmission Losses, but they seem inconsistent with the idea of an "electricity supply mix" of this category. How to proceed?