### PR TITLE
Move energy use of carbon-removal to own section

### DIFF
--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -90,6 +90,40 @@
     description: Final energy consumption of non-renewable waste by the industrial sector
     unit: EJ/yr
 
+# energy use for carbon removal technologies
+- Final Energy|Carbon Removal:
+    description: Total energy use for carbon removal
+    unit: EJ/yr
+- Final Energy|Carbon Removal|Electricity:
+    description: Electricity use for carbon removal
+    unit: EJ/yr
+    notes: See `Secondary Energy|Electricity|...` for the power generation mix
+- Final Energy|Carbon Removal|{Secondary Fuel}:
+    description: Use of {Secondary Fuel} for carbon removal
+    unit: EJ/yr
+    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+- Final Energy|Carbon Removal|Other:
+    description: Use of other energy sources for carbon removal
+    unit: EJ/yr
+- Final Energy|Carbon Removal|{Carbon Removal Option}:
+    description: Energy use for carbon removal by {Carbon Removal Option}
+    unit: EJ/yr
+- Final Energy|Carbon Removal|{Carbon Removal Option}|Electricity:
+    description: Electricity use for carbon removal by {Carbon Removal Option}
+    unit: EJ/yr
+    notes: See `Secondary Energy|Electricity|...` for the power generation mix
+    navigate: Final Energy|Carbon Removal|Electricity|Direct Air Capture
+    engage: Final Energy|Carbon Removal|Electricity|Direct Air Capture
+- Final Energy|Carbon Removal|{Carbon Removal Option}|{Secondary Fuel}:
+    description: Use of {Secondary Fuel} for carbon removal by {Carbon Removal Option}
+    unit: EJ/yr
+    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+    navigate: Final Energy|Carbon Removal|{Secondary Fuel}|Direct Air Capture
+    engage: Final Energy|Carbon Removal|{Secondary Fuel}|Direct Air Capture
+- Final Energy|Carbon Removal|{Carbon Removal Option}|Other:
+    description: Use of other energy sources for carbon removal by {Carbon Removal Option}
+    unit: EJ/yr
+
 # additional variable for bunkers
 - Final Energy|Bunkers|{Bunker Sector}:
     description: Final energy consumption of bunker fuels for {Bunker Sector}

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -53,11 +53,5 @@
         description: passenger transportation sector
     - Bunkers:
         description: bunker-fuels sector
-    - Carbon Removal:
-        description: carbon dioxide removal processes
-    - Carbon Removal|Direct Air Capture:
-        description: direct air capture sector
-    - Carbon Removal|Enhanced Weathering:
-        description: enhanced weathering sector
     - Other Sector:
         description: other sectors

--- a/definitions/variable/energy/tag_carbon_removal.yaml
+++ b/definitions/variable/energy/tag_carbon_removal.yaml
@@ -5,3 +5,7 @@
         description: enhanced weathering
     - Ocean Alkalinity Enhancement:
         description: enhancement of ocean alkalinity
+    - Biochar:
+        description: production of biochar using pyrolysis
+    - Other:
+        description: other methods not explicitly listed

--- a/definitions/variable/energy/tag_carbon_removal.yaml
+++ b/definitions/variable/energy/tag_carbon_removal.yaml
@@ -7,5 +7,5 @@
         description: enhancement of ocean alkalinity
     - Biochar:
         description: production of biochar using pyrolysis
-    - Other:
+    - Other Method:
         description: other methods not explicitly listed

--- a/definitions/variable/energy/tag_carbon_removal.yaml
+++ b/definitions/variable/energy/tag_carbon_removal.yaml
@@ -1,0 +1,5 @@
+- Carbon Removal Option:
+    - Direct Air Capture:
+        description: direct air capture
+    - Enhanced Weathering:
+        description: enhanced weathering

--- a/definitions/variable/energy/tag_carbon_removal.yaml
+++ b/definitions/variable/energy/tag_carbon_removal.yaml
@@ -3,3 +3,5 @@
         description: direct air capture
     - Enhanced Weathering:
         description: enhanced weathering
+    - Ocean Alkalinity Enhancement:
+        description: enhancement of ocean alkalinity


### PR DESCRIPTION
This PR does the following:
- move the variables for energy use for carbon removal to own section
- switch the ordering of the hierarchy from "fuel - technology" to "technology - fuel" for consistency with other "Final Energy" variables

Open questions: are there other carbon-removal technologies that should be included for reporting of their energy use?

Any comments @IAMconsortium/common-definitions-coordination @gidden?