### PR TITLE
Add multiple versions of carbon-price variables

### DIFF
--- a/definitions/variable/socio-economic/carbon-price.yaml
+++ b/definitions/variable/socio-economic/carbon-price.yaml
@@ -1,0 +1,26 @@
+- Price|Carbon:
+    description: Price of carbon (as reported by the model)
+    unit: USD_2010/t CO2
+    region-aggregation:
+      - Price|Carbon (mean):
+          method: mean
+      - Price|Carbon (weighted by Emissions|CO2):
+          weight: Emissions|CO2
+          drop_negative_weights: false
+      - Price|Carbon (weighted by Final Energy):
+          weight: Final Energy
+    check-aggregate: false
+- Price|Carbon (mean):
+    description: Price of carbon (computed as unweighted mean across regions)
+    unit: USD_2010/t CO2
+    skip-region-aggregation: true
+- Price|Carbon (weighted by Emissions|CO2):
+    description: Price of carbon (weighted by regional CO2 emissions)
+    unit: USD_2010/t CO2
+    skip-region-aggregation: true
+    note: Regional CO2 emissions can turn negative at different points in time, which
+      can result in counter-intuitive timeseries when used as weights for averages
+- Price|Carbon (weighted by Final Energy):
+    description: Price of carbon (weighted by final energy consumption across regions)
+    unit: USD_2010/t CO2
+    skip-region-aggregation: true


### PR DESCRIPTION
This PR adds the carbon-price variables (with different forms of aggregation) as used in the ENGAGE project.

fyi @IAMconsortium/common-definitions-coordination 