### PR TITLE
Change "Bunkers" sector to mean international aviation and shipping

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -42,13 +42,13 @@
 - Emissions|{Tier-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Tier-3 Species} from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
-      including emissions from international bunkers, net of negative emissions from
-      bioenergy with CCS (BECCS) in these sectors
+      including emissions from international bunker fuels, net of negative emissions
+      from bioenergy with CCS (BECCS) in these sectors
     unit: "{Tier-3 Species}"
 - Gross Emissions|CO2|Energy and Industrial Processes:
     definition: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
-      including emissions from international bunkers, not accounting for
+      including emissions from international bunker fuels, not accounting for
       negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -133,23 +133,23 @@
     unit: Mt CO2/yr
 - Emissions|{Tier-2 Species}|Energy|Demand|Residential and Commercial:
     description: Emissions of {Tier-2 Species} from fuel combustion in residential,
-      commercial and institutional sectors (IPCC category 1A4a, 1A4b)
+      commercial and institutional sectors (IPCC category 1A4a and 1A4b)
     unit: "{Tier-2 Species}"
 - Emissions|{Tier-2 Species}|Energy|Demand|Transportation:
-    description: Emissions of {Tier-2 Species} from fuel combustion in transportation sector
-      (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei)
+    description: Emissions of {Tier-2 Species} from fuel combustion in transportation (IPCC category 1A3),
+      excluding emissions from international bunker fuels (IPCC category 1A3ai and 1A3di),
+      excluding pipeline emissions (IPCC category 1A3ei)
     unit: "{Tier-2 Species}"
 - Emissions|CO2|Energy|Demand|AFOFI:
-    definition: Emissions of carbon dioxide (CO2) from fuel combustion in agriculture,
+    description: Emissions of carbon dioxide (CO2) from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Bunkers:
-    definition: Emissions of carbon dioxide (CO2) from international bunker fuels
+    description: Emissions of carbon dioxide (CO2) from international bunker fuels
       (IPCC category 1A3ai and 1A3di)
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Bunkers|{Bunker Sector}:
-    definition: Emissions of carbon dioxide (CO2) from international bunker fuels
-        for {Bunker Sector}
+    description: Emissions of carbon dioxide (CO2) from bunker fuels for {Bunker Sector}
     unit: Mt CO2/yr
 - Emissions|{Tier-2 Species}|Energy|Demand|Other Sector:
     description: Emissions of {Tier-2 Species} from fuel combustion in other sectors

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -4,9 +4,9 @@
       including non-energy use, excluding transmission/distribution losses
     unit: EJ/yr
 - Final Energy (w/o bunkers):
-    description: Final energy consumption by all end-use sectors and all fuels,
-      including non-energy use, excluding transmission/distribution losses,
-      excluding international aviation and shipping (see "Bunkers")
+    description: Final energy consumption by all end-use sectors and all fuels
+      including non-energy use, excluding international aviation and shipping (see "Bunkers"),
+      excluding transmission/distribution losses
     unit: EJ/yr
 
 # Non-energy use
@@ -126,14 +126,14 @@
 
 # additional variable for international aviation and shipping ("Bunkers")
 - Final Energy|Bunkers|{Bunker Sector}:
-    description: Final energy consumption of bunker fuels for {Bunker Sector}
+    description: Final energy consumption for {Bunker Sector}
     unit: EJ/yr
 - Final Energy|Bunkers|{Transportation Sector}:
-    description: Final energy consumption of bunker fuels for {Transportation Sector}
+    description: Final energy consumption for {Transportation Sector}
+      in international aviation and shipping
     unit: EJ/yr
 - Final Energy|Bunkers|{Bunker Sector}|{Transportation Sector}:
-    description: Final energy consumption of bunker fuels for {Transportation Sector}
-      on {Bunker Sector}
+    description: Final energy consumption for {Transportation Sector} in {Bunker Sector}
     unit: EJ/yr
     engage: Final Energy|Bunkers|{Transportation Sector}|{Bunker Sector}
     navigate: Final Energy|Bunkers|{Transportation Sector}|{Bunker Sector}

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -1,12 +1,12 @@
 # Aggregate variables
 - Final Energy:
     description: Final energy consumption by all end-use sectors and all fuels,
-      excluding transmission/distribution losses, including non-energy use
+      including non-energy use, excluding transmission/distribution losses
     unit: EJ/yr
 - Final Energy (w/o bunkers):
     description: Final energy consumption by all end-use sectors and all fuels,
-      excluding transmission/distribution losses, including non-energy use,
-      excluding international bunker fuels
+      including non-energy use, excluding transmission/distribution losses,
+      excluding international aviation and shipping (see "Bunkers")
     unit: EJ/yr
 
 # Non-energy use
@@ -90,7 +90,7 @@
     description: Final energy consumption of non-renewable waste by the industrial sector
     unit: EJ/yr
 
-# additional variable for bunkers
+# additional variable for international aviation and shipping ("Bunkers")
 - Final Energy|Bunkers|{Bunker Sector}:
     description: Final energy consumption of bunker fuels for {Bunker Sector}
     unit: EJ/yr

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -49,9 +49,10 @@
     - Transportation|Domestic Shipping:
         description: domestic shipping sector
     - Transportation|Passenger:
-        description: passenger transportation sector
+        description: passenger transportation sector excluding international aviation
+          and shipping
     - Transportation|Freight:
-        description: passenger transportation sector
+        description: freight transportation sector excluding international aviation and shipping
     - Bunkers:
         description: international aviation and shipping
     - Other Sector:

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -54,11 +54,5 @@
         description: passenger transportation sector
     - Bunkers:
         description: international aviation and shipping
-    - Carbon Removal:
-        description: carbon dioxide removal processes
-    - Carbon Removal|Direct Air Capture:
-        description: direct air capture sector
-    - Carbon Removal|Enhanced Weathering:
-        description: enhanced weathering sector
     - Other Sector:
         description: other sectors

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -32,9 +32,10 @@
     - Residential and Commercial:
         description: residential and commercial sector
     - Transportation:
-        description: transportation sector excluding bunker fuels
+        description: transportation sector excluding international aviation and shipping
+          (see "Bunkers")
     - Transportation (w/ bunkers):
-        description: transportation sector including bunker fuels
+        description: transportation sector including international aviation and shipping
     - Transportation|Bus:
         description: transportation sector by bus
     - Transportation|Light Duty Vehicle:
@@ -52,7 +53,7 @@
     - Transportation|Freight:
         description: passenger transportation sector
     - Bunkers:
-        description: bunker-fuels sector
+        description: international aviation and shipping
     - Carbon Removal:
         description: carbon dioxide removal processes
     - Carbon Removal|Direct Air Capture:


### PR DESCRIPTION
This PR responds to a comment by @strefler in #36. It (proposes to) change the meaning of the Bunkers sector include all international aviation and shipping to avoid an inconsistency between oil and green fuels in international transportation.