### PR TITLE
Add GDP variables

### DIFF
--- a/definitions/variable/macro-economy/gdp.yaml
+++ b/definitions/variable/macro-economy/gdp.yaml
@@ -1,0 +1,6 @@
+- GDP|MER:
+    definition: GDP converted to USD at market exchange rate (MER)
+    unit: billion USD_2010/yr
+- GDP|PPP:
+    definition: GDP converted to USD using purchasing power parity (PPP)
+    unit: billion USD_2010/yr


### PR DESCRIPTION
This PR adds GDP variables in response to #53 using the 2010-USD as unit - however, the latest SSP-release (see http://data.ece.iiasa.ac.at/ssp/) used 2017-USD as unit for GDP projections.

Any suggestions/preferences on which one to use?
@IAMconsortium/common-definitions-coordination @IAMconsortium/common-definitions-macro-economy 