### PR TITLE
Guard against adding deprecated legacy variables

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v4

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,0 +1,32 @@
+# This workflow validates that (new) variables are not referenced as deprecated legacy variables
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Validate the project
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  project-validation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install requirements
+      run: pip install -r requirements.txt
+
+    - name: Install pytest
+      run: pip install pytest
+
+    - name: Run the legacy validation
+      run: pytest tests/test_legacy.py

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,7 +1,7 @@
 # This workflow validates that (new) variables are not referenced as deprecated legacy variables
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Validate the project
+name: Guard against legacy variables
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
     branches: [ '**' ]
 
 jobs:
-  project-validation:
+  legacy-validation:
 
     runs-on: ubuntu-latest
 

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -108,9 +108,6 @@
 - Final Energy|Carbon Removal|{Carbon Removal Option}:
     description: Energy use for carbon removal by {Carbon Removal Option}
     unit: EJ/yr
-- Final Energy|Carbon Removal|Electricity|{Carbon Removal Option}:
-    description: Electricity use for carbon removal by {Carbon Removal Option}
-    unit: EJ/yr
 - Final Energy|Carbon Removal|{Carbon Removal Option}|Electricity:
     description: Electricity use for carbon removal by {Carbon Removal Option}
     unit: EJ/yr

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -108,6 +108,9 @@
 - Final Energy|Carbon Removal|{Carbon Removal Option}:
     description: Energy use for carbon removal by {Carbon Removal Option}
     unit: EJ/yr
+- Final Energy|Carbon Removal|Electricity|{Carbon Removal Option}:
+    description: Electricity use for carbon removal by {Carbon Removal Option}
+    unit: EJ/yr
 - Final Energy|Carbon Removal|{Carbon Removal Option}|Electricity:
     description: Electricity use for carbon removal by {Carbon Removal Option}
     unit: EJ/yr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nomenclature-iamc >= 0.12
+nomenclature-iamc >= 0.16

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,0 +1,25 @@
+from nomenclature import DataStructureDefinition
+
+
+def test_legacy_variables():
+    # Check that (new) variables are not referenced as deprecated legacy variables
+    dsd = DataStructureDefinition("definitions/", dimensions=["variable"])
+    existing_variables = list(dsd.variable)
+
+    legacy_variables = {}
+    for code, attrs in dsd.variable.items():
+        for project in ["navigate", "engage"]:
+            if project in attrs.extra_attributes:
+                legacy_var = attrs.__getattr__(project)
+                if legacy_var in existing_variables:
+                    legacy_variables[legacy_var] = code
+
+    if legacy_variables:
+        error = [
+            f"'{legacy_var}' -> '{code}'" + "\n"
+            for legacy_var, code in legacy_variables.items()
+        ]
+
+        raise ValueError(
+            "Deprecated variables from legacy projects:\n" f"{''.join(error)}"
+        )


### PR DESCRIPTION
This PR adds a test and GitHub Actions workflow to guard against mistakenly adding variables that were marked as being superseded by new variables.

The way that legacy variables are marked in the common-definitions repository is by having an attribute with the legacy project name, currently "navigate" and "engage".

```yaml
- Final Energy|Carbon Removal|{Carbon Removal Option}|Electricity:
    description: Electricity use for carbon removal by {Carbon Removal Option}
    unit: EJ/yr
    notes: See `Secondary Energy|Electricity|...` for the power generation mix
    navigate: Final Energy|Carbon Removal|Electricity|{Carbon Removal Option}
```

The test workflow checks that all such attributes are not duplicates of variables in the VariableCodeList.
