### PR TITLE
Refactoring emissions-species detail categorization to `level`

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -1,50 +1,54 @@
-- Emissions|{Tier-1 Species}:
-    description: Emissions of {Tier-1 Species}
-    unit: "{Tier-1 Species}"
+# Emissions species are grouped into three levels of detail for the reporting.
+# Level-1 reports aggregate emissions, Level-3 has the most detailed disaggregation.
+# Gross emissions are only defined for CO2.
+
+- Emissions|{Level-1 Species}:
+    description: Emissions of {Level-1 Species}
+    unit: "{Level-1 Species}"
 - Gross Emissions|CO2:
     definition: Gross emissions of carbon dioxide (CO2), not accounting for negative
       emissions from bioenergy with CCS (BECCS) or agriculture, forestry
       and other land use (AFOLU)
     unit: Mt CO2/yr
 
-- Emissions|{Tier-2 Species}|AFOLU:
-    description: Emissions of {Tier-2 Species} from agriculture, forestry
+- Emissions|{Level-2 Species}|AFOLU:
+    description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC category 3)
-    unit: "{Tier-2 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture:
-    description: Emissions of {Tier-3 Species} from the agriculture sector
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture|Livestock:
-    description: Emissions of {Tier-3 Species} from livestock in the agriculture sector
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture|Livestock|Enteric Fermentation:
-    description: Emissions of {Tier-3 Species} from enteric fermentation of livestock
+    unit: "{Level-2 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture:
+    description: Emissions of {Level-3 Species} from the agriculture sector
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock:
+    description: Emissions of {Level-3 Species} from livestock in the agriculture sector
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Enteric Fermentation:
+    description: Emissions of {Level-3 Species} from enteric fermentation of livestock
       in the agriculture sector
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture|Livestock|Manure Management:
-    description: Emissions of {Tier-3 Species} from processes involving
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Manure Management:
+    description: Emissions of {Level-3 Species} from processes involving
       manure (waste) management in Livestock in the agriculture sector
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture|Rice:
-    description: Emissions of {Tier-3 Species} from rice cultivation
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Agriculture|Managed Soils:
-    description: Emissions of {Tier-3 Species} from soil management practices
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture|Rice:
+    description: Emissions of {Level-3 Species} from rice cultivation
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Agriculture|Managed Soils:
+    description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Land:
-    description: Emissions of {Tier-3 Species} from forestry and other land use
-    unit: "{Tier-3 Species}"
-- Emissions|{Tier-3 Species}|AFOLU|Land|Wetlands:
-    description: Emissions of {Tier-3 Species} from managed peatlands (drained and rewetted)
-    unit: "{Tier-3 Species}"
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land:
+    description: Emissions of {Level-3 Species} from forestry and other land use
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
+    description: Emissions of {Level-3 Species} from managed peatlands (drained and rewetted)
+    unit: "{Level-3 Species}"
 
-- Emissions|{Tier-3 Species}|Energy and Industrial Processes:
-    description: Emissions of {Tier-3 Species} from energy use in supply and demand sectors
+- Emissions|{Level-3 Species}|Energy and Industrial Processes:
+    description: Emissions of {Level-3 Species} from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
       including emissions from international bunker fuels, net of negative emissions
       from bioenergy with CCS (BECCS) in these sectors
-    unit: "{Tier-3 Species}"
+    unit: "{Level-3 Species}"
 - Gross Emissions|CO2|Energy and Industrial Processes:
     definition: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
@@ -52,23 +56,23 @@
       negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
 
-- Emissions|{Tier-2 Species}|Energy:
-    description: Emissions of {Tier-2 Species} from energy use,
+- Emissions|{Level-2 Species}|Energy:
+    description: Emissions of {Level-2 Species} from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B)
-    unit: "{Tier-2 Species}"
+    unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy:
     definition: Gross emissions of carbon dioxide (CO2) from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for
       negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
-- Emissions|{Tier-2 Species}|Energy|Supply:
-    description: Emissions of {Tier-2 Species} from fuel combustion and fugitive emissions
+- Emissions|{Level-2 Species}|Energy|Supply:
+    description: Emissions of {Level-2 Species} from fuel combustion and fugitive emissions
       from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
       other energy conversion (e.g., refineries, synfuel production, solid fuel processing,
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei),
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
       transport and storage (IPCC category 1C)
-    unit: "{Tier-2 Species}"
+    unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Supply:
     definition: Gross emissions of carbon dioxide (CO2) from fuel combustion and fugitive emissions
       from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
@@ -107,13 +111,13 @@
       not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
 
-- Emissions|{Tier-2 Species}|Energy|Demand:
-    description: Emissions of {Tier-2 Species} from fuel combustion in industry (IPCC category 1A2),
+- Emissions|{Level-2 Species}|Energy|Demand:
+    description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2),
       residential, commercial, institutional sectors and agriculture, forestry,
       fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and transportation sector
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
       net of negative emissions incl. demand-side use of bioenergy with CCS (BECCS)
-    unit: "{Tier-2 Species}"
+    unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
       residential, commercial, institutional sectors and agriculture, forestry,
@@ -121,9 +125,9 @@
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
       not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
-- Emissions|{Tier-2 Species}|Energy|Demand|Industry:
-    description: Emissions of {Tier-2 Species} from fuel combustion in industry (IPCC category 1A2)
-    unit: "{Tier-2 Species}"
+- Emissions|{Level-2 Species}|Energy|Demand|Industry:
+    description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)
+    unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
@@ -131,15 +135,15 @@
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
     unit: Mt CO2/yr
-- Emissions|{Tier-2 Species}|Energy|Demand|Residential and Commercial:
-    description: Emissions of {Tier-2 Species} from fuel combustion in residential,
+- Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial:
+    description: Emissions of {Level-2 Species} from fuel combustion in residential,
       commercial and institutional sectors (IPCC category 1A4a and 1A4b)
-    unit: "{Tier-2 Species}"
-- Emissions|{Tier-2 Species}|Energy|Demand|Transportation:
-    description: Emissions of {Tier-2 Species} from fuel combustion in transportation (IPCC category 1A3),
+    unit: "{Level-2 Species}"
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation:
+    description: Emissions of {Level-2 Species} from fuel combustion in transportation (IPCC category 1A3),
       excluding emissions from international bunker fuels (IPCC category 1A3ai and 1A3di),
       excluding pipeline emissions (IPCC category 1A3ei)
-    unit: "{Tier-2 Species}"
+    unit: "{Level-2 Species}"
 - Emissions|CO2|Energy|Demand|AFOFI:
     description: Emissions of carbon dioxide (CO2) from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)
@@ -151,28 +155,28 @@
 - Emissions|CO2|Energy|Demand|Bunkers|{Bunker Sector}:
     description: Emissions of carbon dioxide (CO2) from bunker fuels for {Bunker Sector}
     unit: Mt CO2/yr
-- Emissions|{Tier-2 Species}|Energy|Demand|Other Sector:
-    description: Emissions of {Tier-2 Species} from fuel combustion in other sectors
-    unit: "{Tier-2 Species}"
+- Emissions|{Level-2 Species}|Energy|Demand|Other Sector:
+    description: Emissions of {Level-2 Species} from fuel combustion in other sectors
+    unit: "{Level-2 Species}"
 
-- Emissions|{Tier-3 Species}|Industrial Processes:
-    description: Emissions of {Tier-3 Species} from industrial processes
+- Emissions|{Level-3 Species}|Industrial Processes:
+    description: Emissions of {Level-3 Species} from industrial processes
       (IPCC categories 2A, B, C, E), net of negative emissions using CCS
-    unit: "{Tier-3 Species}"
+    unit: "{Level-3 Species}"
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
       (IPCC categories 2A, B, C, E), not accounting for negative emissions from
       bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
-- Emissions|{Tier-3 Species}|Industrial Processes|{Non-Energy Sector}:
-    description: Emissions of {Tier-3 Species} from industrial processes
+- Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}:
+    description: Emissions of {Level-3 Species} from industrial processes
       (IPCC categories 2A, B, C, E) in the {Non-Energy Sector}
-    unit: "{Tier-3 Species}"
+    unit: "{Level-3 Species}"
 
-- Emissions|{Tier-2 Species}|Waste:
-    description: Emissions of {Tier-2 Species} from waste (IPCC category 6)
-    unit: "{Tier-2 Species}"
+- Emissions|{Level-2 Species}|Waste:
+    description: Emissions of {Level-2 Species} from waste (IPCC category 6)
+    unit: "{Level-2 Species}"
 
-- Emissions|{Tier-2 Species}|Other:
-    description: Emissions of {Tier-2 Species} from other sources
-    unit: "{Tier-2 Species}"
+- Emissions|{Level-2 Species}|Other:
+    description: Emissions of {Level-2 Species} from other sources
+    unit: "{Level-2 Species}"

--- a/definitions/variable/emissions/tag_level-1-species.yaml
+++ b/definitions/variable/emissions/tag_level-1-species.yaml
@@ -1,4 +1,6 @@
-- Tier-1 Species:
+# These species are reported for aggregate emissions variables.
+
+- Level-1 Species:
     - CO2:
         description: carbon dioxide (CO2)
         unit: Mt CO2/yr

--- a/definitions/variable/emissions/tag_level-2-species.yaml
+++ b/definitions/variable/emissions/tag_level-2-species.yaml
@@ -1,5 +1,7 @@
-# please make sure that this is list is a subset of `Tier-1 Species`
-- Tier-2 Species:
+# These species are reported for more disaggregated emissions variables.
+# Please make sure that this is list is a subset of `Level-1 Species`
+
+- Level-2 Species:
     - CO2:
         description: carbon dioxide (CO2)
         unit: Mt CO2/yr

--- a/definitions/variable/emissions/tag_level-3-species.yaml
+++ b/definitions/variable/emissions/tag_level-3-species.yaml
@@ -1,5 +1,7 @@
-# please make sure that this is list is a subset of `Tier-2 Species`
-- Tier-3 Species:
+# These species are reported for the most disaggregated emissions variables.
+# Please make sure that this is list is a subset of `Level-2 Species`
+
+- Level-3 Species:
     - CO2:
         description: carbon dioxide (CO2)
         unit: Mt CO2/yr


### PR DESCRIPTION
Because there was some confusion about the use of the term "tier" in the emissions-species tag-lists, this PR refactors the emissions-species tag lists and adds comments

FYI @lolow @FlorianLeblancDr @orichters 