### PR TITLE
Add SDG indicators from the SHAPE project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Read more about the [IAMC data format](https://docs.ece.iiasa.ac.at/iamc.html).
 This project uses the Python package [nomenclature-iamc](https://nomenclature-iamc.readthedocs.io)
 for management of codelists and validation of scenario data in the IAMC data format.
 
+> [!TIP]
+> For *users not comfortable working with GitHub repositories and yaml files*,
+> the definitions for this project are available for download as an xlsx spreadsheet
+> at https://files.ece.iiasa.ac.at/common-definitions/project-template.xlsx.
+
 ## Codelists and mappings
 
 The folder `definitions` contains the "codelists", i.e., list of allowed variables and

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -237,26 +237,6 @@
     unit: '%'
     weight: Population
     shape: GDPpcap|PPP|Ratio to OECD
-- Production|Cement:
-    definition: production of cement
-    sdg: 9
-    unit: Mt/year
-- Production|Steel:
-    definition: production of steel
-    sdg: 9
-    unit: Mt/year
-- Production|Steel|Primary:
-    definition: production of primary steel
-    sdg: 9
-    unit: Mt/year
-- Production|Steel|Secondary:
-    definition: production of secondary steel
-    sdg: 9
-    unit: Mt/year
-- Value Added|Industry|Other Industry:
-    definition:
-    sdg: 9
-    unit: billion US$2010
 - Population|Poverty|National Poverty Line [Share]:
     definition: Share of population living in relative poverty with income below their
       respective national poverty lines

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -225,16 +225,18 @@
     sdg: 7
     unit: EJ/billion USD_2010
     weight: GDP|PPP
-- GDP|PPP|per capita|Growth Rate:
-    definition: GDP/cap (PPP) growth rate
+- GDP|PPP [Growth Rate per capita]:
+    definition: Annual growth rate of GDP-per-capita (PPP)
     sdg: 8
     unit: '%'
     weight: GDP|PPP
-- GDP|PPP|per capita|Relative to OECD [Ratio]:
-    definition: Ratio of GDP/cap (PPP) of country/region to OECD average
+    shape: GDPpcap|PPP|Growth rate
+- GDP|PPP [per capita relative to OECD]:
+    definition: Ratio of GDP-per-capita (PPP) relative to OECD average
     sdg: 8
     unit: '%'
     weight: Population
+    shape: GDPpcap|PPP|Ratio to OECD
 - Production|Cement:
     definition: production of cement
     sdg: 9

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -1,23 +1,25 @@
-- Population|Extreme Poverty|International Poverty Line:
-    definition: population living in extreme poverty with income <US$1.90 2011 PPP
-      per day
+- Population|Poverty|Extreme Poverty:
+    definition: Number of people living in extreme poverty with income
+      below USD_2011 1.90 PPP per day
     sdg: 1
     unit: million
+    shape: Population|Extreme Poverty|International poverty line
 - Population|Poverty|LMIC Poverty Line:
-    definition: population living in poverty with income <US$3.20 2011 PPP per day
-      (World Bank LMIC definition)
+    definition: Number of people living in poverty with income with income
+      below USD_2011 3.20 PPP per day (World Bank LMIC definition)
     sdg: 1
     unit: million
 - Population|Poverty|UMIC Poverty Line:
-    definition: population living in poverty with income <US$5.50 2011 PPP per day
-      (World Bank LMIC definition)
+    definition: Number of people living in poverty with income
+      below USD_2011 5.50 PPP per day (World Bank LMIC definition)
     sdg: 1
     unit: million
-- Expenditure|Food [Share]:
+- Expenditure|Households|Food [Share]:
     definition: Share of food expenditure in total income
     sdg: 1
     unit: '%'
     weight: GDP|PPP
+    shape: Expenditure Share|Food
 - Population|Prevalence of Underweight:
     definition: Number of adults with BMI<18.5 and children with <-2SD from reference
       BMI

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -450,8 +450,8 @@
     sdg: 15
     unit: Tg N/yr
 - Political Institutions|Equality Before Law and Individual Liberty:
-    description: Aggregated 'Equality Before the Law and Individual Liberty' index (0-1)
-      as defined by V-DEM
+    description: Aggregated 'Equality Before the Law and Individual Liberty' index as
+      defined by "Varieties of Democracy" (V-DEM, Coppedge et al., 2022; Pemstein et al., 2022)
     sdg: 16
     unit:
     weight: Population

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -21,40 +21,44 @@
     weight: GDP|PPP
     shape: Expenditure Share|Food
 - Population|Prevalence of Underweight:
-    definition: Number of adults with BMI<18.5 and children with <-2SD from reference
-      BMI
+    definition: Number of adults with body mass index (BMI) lower than 18.5 and 
+      children with BMI lower than two standard deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Underweight|Children:
-    definition: Number of underweight children (<-2SD from reference BMI, aged 0--14)
+    definition: Number of children aged 0-14 years with BMI lower than two standard
+      deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Overweight:
-    definition: Number of adults with BMI>25 and children with >+1SD from reference
-      BMI
+    definition: Number of adults with body mass index (BMI) greater than 25 and
+      children with BMI greater than one standard deviation from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Overweight|Children:
-    definition: Number of overweight children (>+1SD from reference BMI, aged 0--14)
+    definition: Number of children aged 0-14 years with BMI greater than one standard
+      deviation from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Obesity:
-    definition: Number of adults with BMI>30 and children with >+2SD from reference
-      BMI
+    definition: Number of adults with with body mass index (BMI) greater than 30 and
+      children with BMI greater than two standard deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Obesity|Children:
-    definition: Number of obese children (+2SD from reference BMI, aged 0--14)
+    definition: Number of children aged 0-14 with BMI greater than two standard
+      deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Normal Weight:
-    definition: "Number of adults with BMI 18.5\u201325 and children within -2SD and\
-      \ +1SD relative to reference BMI"
+    definition: Number of adults with body mass index (BMI) BMI between 18.5 and 25 and
+      children with BMI within two standard deviations below reference (lower bound)
+        and one standard deviations above reference (upper bound)
     sdg: 2
     unit: million
 - Population|Prevalence of Normal Weight|Children:
-    definition: Number of normal-weight children (within -2SD and +1SD relative to
-      reference BMI, aged 0--14)
+    definition: Number of children aged 0-14 with BMI within two standard deviations
+      below reference (lower bound) and one standard deviations above reference (upper bound)
     sdg: 2
     unit: million
 - Food|Availability [per capita]:

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -389,24 +389,27 @@
     definition: Nitrogen inputs on cropland from other sources
     sdg: 15
     unit: Tg N/yr
-- Political Institutions|Equality before law and individual liberty:
-    definition: Aggregated 'equality Before the Law and Individual Liberty' index (0-1)
+- Political Institutions|Equality Before Law and Individual Liberty:
+    definition: Aggregated 'Equality Before the Law and Individual Liberty' index (0-1)
       as defined by V-DEM
     sdg: 16
-    unit: '-'
+    unit:
     weight: Population
-- Price|Carbon|Relative to OECD [Ratio]:
-    definition: Ratio of carbon price to OECD carbon price
+    shape: Political Institutions|Equality before law and individual liberty
+- Price|Carbon [relative to OECD]:
+    definition: Carbon price relative to OECD carbon price
     sdg: 17
     unit: '%'
     skip-region-aggregation: true
-- Policy Cost|GDP Loss|w/o Transfers:
-    definition: GDP loss (without international transfers) in a policy scenario compared
+    shape: Price|Carbon|Ratio to OECD
+- Policy Cost|GDP Loss w/o Transfers:
+    definition: GDP loss without international transfers in a policy scenario compared
       to the corresponding baseline (losses should be reported as positive numbers)
     sdg: 17
-    unit: billion US$2010/yr
+    unit: billion USD_2010/yr
+    shape: Policy Cost|GDP Loss|w/o transfers
 - Policy Cost|Transfers:
     definition: Net international climate finance transfers (positive for inflow,
       negative for payment)
     sdg: 17
-    unit: billion US$2010/yr
+    unit: billion USD_2010/yr

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -289,13 +289,14 @@
 #     weight: Production|Iron and Steel|Volume
     shape: Material recycling|{Recycled Materials}|Share
 - Agricultural Material Footprint [per capita]:
-    definition: Biomass usage per capita (excluding pasture + forestry)
+    definition: Biomass usage per capita excluding pasture and forestry
     sdg: 12
     unit: tDM/cap/yr
     weight: Population
+    shape: Agricultural Material Footprint
 - Food Waste [per capita]:
-    definition: Amount of food (agriculture and livestock) per capita that is disposed and not
-      consumed
+    definition: Amount of food (crops and livestock) per capita that is disposed
+      and not consumed
     unit: kcal/cap/day
     weight: Population
 - Ocean|pH value:

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -299,20 +299,21 @@
       and not consumed
     unit: kcal/cap/day
     weight: Population
-- Ocean|pH value:
-    definition: 'Ocean acidification: pH value'
+- Ocean|Acidification:
+    definition: Ocean acidification
     sdg: 14
-    unit: '-'
+    unit: pH
     skip-region-aggregation: true
+    shape: Ocean|pH value
 - Ocean|Carbonate Saturation|Aragonite:
-    definition: Saturation state of aragonite (Omega_A)
+    definition: Saturation state of aragonite (Omega A)
     sdg: 14
-    unit: '-'
+    unit:
     skip-region-aggregation: true
 - Ocean|Carbonate Saturation|Calcite:
-    definition: Saturation state of calcite (Omega_C)
+    definition: Saturation state of calcite (Omega C)
     sdg: 14
-    unit: '-'
+    unit:
     skip-region-aggregation: true  
 - Land Cover|Forest|Natural Forest|Primary Forest:
     definition: Undisturbed primary natural forests

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -250,30 +250,33 @@
     unit: '%'
     weight: Population
     shape: Population|Relative poverty|wrt median income|Share
-- Inequality|Bottom 40% average income [Ratio]:
-    definition: Average income of bottom 40% relative to national average
+- Inequality|Average Income|Bottom 40% [Ratio]:
+    definition: Average income of bottom 40% of population relative to national average
     sdg: 10
     unit: '%'
     weight: Population
+    shape: Inequality|Bottom 40% average income|Ratio
 - Population|Informal Settlements:
-    definition: population living in informal settlements (e.g. slums)
+    definition: Number of people living in informal settlements, e.g., slums
     sdg: 11
     unit: million
-- Population|substandard accommodation:
-    definition: population living in substandard accommodation (e.g. accommodation
+- Population|Substandard Accommodation:
+    definition: Number of people living in substandard accommodation, e.g., accommodation
       that does not meet legal requirements and/or enable well being for the occupants
     sdg: 11
     unit: million
+    shape: Population|substandard accommodation
 - Population|Urban [Share]:
-    definition: share of population living in urban areas
+    definition: Share of population living in urban areas
     sdg: 11
     unit: '%'
     weight: Population
-- Air Pollution|PM2.5|Urban population:
+- Air Pollution|PM2.5|Urban Population:
     definition: Urban population weighted annual average PM2.5 concentrations.
     sdg: 11
     unit: ug/m3
     weight: Population|Urban
+    shape: Air Pollution|PM2.5|Urban population
 - Material Recycling|Chemicals:
     definition: Production of Recycled Chemicals
     sdg: 12

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -365,47 +365,50 @@
     description: Modified natural forests and secondary forests from natural succession
     sdg: 15
     unit: million ha      
-- Terrestrial Biodiversity|MSA:
+- Terrestrial Biodiversity|Mean Species Abundance:
     description: Terrestrial biodiversity measured in Mean Species Abundance (MSA)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
     weight: Land Cover
-- Terrestrial Biodiversity|MSA|Vertebrates:
+- Terrestrial Biodiversity|Mean Species Abundance|Vertebrates:
     definition: Terrestrial biodiversity of vertebrate species measured in Mean Species
       Abundance (MSA)
     unit: '%'
     weight: Land Cover
-- Terrestrial Biodiversity|MSA|Plants:
+    navigate: Terrestrial Biodiversity|MSA|Vertebrates
+- Terrestrial Biodiversity|Mean Species Abundance|Plants:
     definition: Terrestrial biodiversity of plant species measured in Mean Species
       Abundance (MSA)
     unit: '%'
     weight: Land Cover
-- Terrestrial Biodiversity|BII:
+    navigate: Terrestrial Biodiversity|MSA|Vertebrates
+- Terrestrial Biodiversity|Biodiversity Intactness Index:
     definition: Terrestrial biodiversity measured with Biodiversity Intactness Index
       (BII)
     unit: '%'
     weight: Land Cover
-- Terrestrial Biodiversity|BII|Cropland Landscapes:
+    navigate: Terrestrial Biodiversity|BII
+- Terrestrial Biodiversity|Biodiversity Intactness Index|Cropland Landscapes:
     description: Terrestrial biodiversity in landscapes containing cropland measured
       with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
     weight: Land Cover|Cropland
-- Terrestrial Biodiversity|BII|Biodiversity Hotspots:
+- Terrestrial Biodiversity|Biodiversity Intactness Index|Biodiversity Hotspots:
     description: Terrestrial biodiversity in biodiversity hotspot landscapes measured
       with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
-- Terrestrial Biodiversity|BII|Key Conservation Landscapes:
+- Terrestrial Biodiversity|Biodiversity Intactness Index|Key Conservation Landscapes:
     description: Terrestrial biodiversity in biodiversity hotspot and intact forest landscapes
       measured with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
-- Terrestrial Biodiversity|BII|Areas Outside Key Conservation and Cropland Landscapes:
+- Terrestrial Biodiversity|Biodiversity Intactness Index|Areas Outside Key Conservation and Cropland Landscapes:
     description: Terrestrial biodiversity in areas outside biodiversity hotspot,
       intact forest & cropland landscapes measured with Biodiversity Intactness Index (BII)
     sdg: 15

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -170,12 +170,12 @@
     sdg: 6
     unit: km3/yr
 - Useful Energy|Transportation|Passenger [per capita]:
-    definition: Useful energy per capita for passenger transport.
+    definition: Useful energy per capita for passenger transport
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
 - Useful Energy|Industry [per capita]:
-    definition: Useful energy per capita for industry.
+    definition: Useful energy per capita for industry
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
@@ -185,42 +185,45 @@
     unit: GJ/cap/yr
     weight: Population
 - Energy Service|Passenger|Road:
-    definition: energy service demand for passenger transport on roads
+    definition: Energy service demand for passenger transport on roads
     sdg: 7
-    unit: bn pkm/yr
-- Energy Service|Transportation|Passenger|ActiveTransport [Share]:
-    definition: Walking and Cycling share of passenger transport
-    sdg: 7
-    unit: '%'
-    skip-region-aggregation: true
-#     weight: Energy Service|Transportation|Passenger
-- Energy Service|Transportation|Passenger|PublicTransport [Share]:
-    definition: Public share of passenger transport
+    unit: billion pkm/yr
+- Energy Service|Transportation|Passenger|Active Transport [Share]:
+    definition: Shae of walking and cycling in passenger transport
     sdg: 7
     unit: '%'
     skip-region-aggregation: true
 #     weight: Energy Service|Transportation|Passenger
+    shape: Energy Service|Transportation|Passenger|ActiveTransport|Share
+- Energy Service|Transportation|Passenger|Public Transport [Share]:
+    definition: Share of public transit in passenger transport
+    sdg: 7
+    unit: '%'
+    skip-region-aggregation: true
+#     weight: Energy Service|Transportation|Passenger
+    shape: Energy Service|Transportation|Passenger|PublicTransport|Share
 - Energy Service|Residential|Cooling Degree Days:
     definition:
     sdg: 7
-    unit: C days
+    unit: °C-days
     skip-region-aggregation: true
 #     weight: Energy Service|Residential|Floor Space
 - Energy Service|Residential|Heating Degree Days:
     definition:
     sdg: 7
-    unit: C days
+    unit: °C-days
     skip-region-aggregation: true
 #     weight: Energy Service|Residential|Floor Space
 - Final Energy|Industry|Electricity [Share]:
-    definition: Share of electrified final energy demand of industry
+    definition: Share of electricity in final energy demand for industry
     sdg: 7
     unit: '%'
     weight: Final Energy|Industry|Electricity
+    shape: Final Energy|Industry|Electricity|Share
 - Intensity|Final Energy:
     definition: Final Energy intensity
     sdg: 7
-    unit: EJ/billion US$2010
+    unit: EJ/billion USD_2010
     weight: GDP|PPP
 - GDP|PPP|per capita|Growth Rate:
     definition: GDP/cap (PPP) growth rate

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -324,35 +324,39 @@
     sdg: 15
     unit: million ha      
 - Terrestrial Biodiversity|MSA:
-    definition: Terrestrial biodiversity measured in Mean Species
-      Abundance (MSA)
+    definition: Terrestrial biodiversity measured in Mean Species Abundance (MSA)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 #     weight: Land Cover
 - Terrestrial Biodiversity|BII|Cropland Landscapes:
-    definition: Terrestrial biodiversity in landscapes containing cropland measured with Biodiversity Intactness Index (BII)
+    definition: Terrestrial biodiversity in landscapes containing cropland measured
+      with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 #     weight: Land Cover|Cropland
 - Terrestrial Biodiversity|BII|Biodiversity Hotspots:
-    definition: Terrestrial biodiversity in biodiversity hotspot landscapes measured with Biodiversity Intactness Index (BII)
+    definition: Terrestrial biodiversity in biodiversity hotspot landscapes measured
+      with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|BII|Key Conservation Landscapes:
-    definition: Terrestrial biodiversity in biodiversity hotspot and intact forest landscapes measured with Biodiversity Intactness Index (BII)
+    definition: Terrestrial biodiversity in biodiversity hotspot and intact forest landscapes
+      measured with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|BII|Areas Outside Key Conservation and Cropland Landscapes:
-    definition: Terrestrial biodiversity in areas outside biodiversity hotspot, intact forest & cropland landscapes measured with Biodiversity Intactness Index (BII)
+    definition: Terrestrial biodiversity in areas outside biodiversity hotspot,
+      intact forest & cropland landscapes measured with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|Shannon Crop Diversity Index:
-    definition: Crop diversity measured by the Shannon index accounting for crop richness and abundance
+    definition: Crop diversity measured by the Shannon index accounting for crop richness
+      and abundance
     sdg: 15
     unit: index
     skip-region-aggregation: true

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -152,22 +152,11 @@
     definition: Number of people living in areas with severe water stress
     sdg: 6
     unit: million
-- Nitrogen|Pollution|Surplus|Animal Waste Management:
-    definition: Nitrogen surplus in animal waste management
+- Pollution|Nitrogen|Surplus|{Nitrogen Sources}:
+    description: Nitrogen surplus of {Nitrogen Sources}
     sdg: 6
     unit: Tg N/yr
-- Nitrogen|Pollution|Surplus|Cropland:
-    definition: Nitrogen surplus of soil inputs over soil withdrawals in cropland
-    sdg: 6
-    unit: Tg N/yr
-- Nitrogen|Pollution|Surplus|Non-agricultural Land:
-    definition: Nitrogen surplus in non-agricultural land
-    sdg: 6
-    unit: Tg N/yr
-- Nitrogen|Pollution|Surplus|Pasture:
-    definition: Nitrogen surplus of soil inputs over soil withdrawals in pasture
-    sdg: 6
-    unit: Tg N/yr 
+    shape: Nitrogen|Pollution|Surplus|{Nitrogen Sources}
 - Water Quality|Nitrogen Concentration:
     definition: Concentration of nitrogen in water at river mouths
     sdg: 6

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -1,155 +1,155 @@
 - Population|Poverty|Extreme Poverty:
-    definition: Number of people living in extreme poverty with income
+    description: Number of people living in extreme poverty with income
       below USD_2011 1.90 PPP per day
     sdg: 1
     unit: million
     shape: Population|Extreme Poverty|International poverty line
 - Population|Poverty|LMIC Poverty Line:
-    definition: Number of people living in poverty with income with income
+    description: Number of people living in poverty with income with income
       below USD_2011 3.20 PPP per day (World Bank LMIC definition)
     sdg: 1
     unit: million
 - Population|Poverty|UMIC Poverty Line:
-    definition: Number of people living in poverty with income
+    description: Number of people living in poverty with income
       below USD_2011 5.50 PPP per day (World Bank LMIC definition)
     sdg: 1
     unit: million
 - Expenditure|Households|Food [Share]:
-    definition: Share of food expenditure in total income
+    description: Share of food expenditure in total income
     sdg: 1
     unit: '%'
     weight: GDP|PPP
     shape: Expenditure Share|Food
 - Population|Prevalence of Underweight:
-    definition: Number of adults with body mass index (BMI) lower than 18.5 and 
+    description: Number of adults with body mass index (BMI) lower than 18.5 and 
       children with BMI lower than two standard deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Underweight|Children:
-    definition: Number of children aged 0-14 years with BMI lower than two standard
+    description: Number of children aged 0-14 years with BMI lower than two standard
       deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Overweight:
-    definition: Number of adults with body mass index (BMI) greater than 25 and
+    description: Number of adults with body mass index (BMI) greater than 25 and
       children with BMI greater than one standard deviation from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Overweight|Children:
-    definition: Number of children aged 0-14 years with BMI greater than one standard
+    description: Number of children aged 0-14 years with BMI greater than one standard
       deviation from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Obesity:
-    definition: Number of adults with with body mass index (BMI) greater than 30 and
+    description: Number of adults with with body mass index (BMI) greater than 30 and
       children with BMI greater than two standard deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Obesity|Children:
-    definition: Number of children aged 0-14 with BMI greater than two standard
+    description: Number of children aged 0-14 with BMI greater than two standard
       deviations from reference
     sdg: 2
     unit: million
 - Population|Prevalence of Normal Weight:
-    definition: Number of adults with body mass index (BMI) BMI between 18.5 and 25 and
+    description: Number of adults with body mass index (BMI) BMI between 18.5 and 25 and
       children with BMI within two standard deviations below reference (lower bound)
         and one standard deviations above reference (upper bound)
     sdg: 2
     unit: million
 - Population|Prevalence of Normal Weight|Children:
-    definition: Number of children aged 0-14 with BMI within two standard deviations
+    description: Number of children aged 0-14 with BMI within two standard deviations
       below reference (lower bound) and one standard deviations above reference (upper bound)
     sdg: 2
     unit: million
 - Food|Availability [per capita]:
-    definition: Amount of food available for consumption per capita
+    description: Amount of food available for consumption per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
 - Food|Availability|{Food Options} [per capita]:
-    definition: Amount of {Food Options} available for consumption per capita
+    description: Amount of {Food Options} available for consumption per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
 - Food|Intake [per capita]:
-    definition: Food calorie intake per capita
+    description: Food calorie intake per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
 - Food|Intake|{Food Options} [per capita]:
-    definition: Calorie intake of {Food Options} per capita
+    description: Calorie intake of {Food Options} per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
 - Price|Agriculture|Livestock|Index:
-    definition: Weighted average price index of livestock
+    description: Weighted average price index of livestock
     sdg: 2
     unit: Index (2020 = 1)
     skip-region-aggregation: true
 #     weight: Agricultural Production|Non-Energy
 - Health|Premature Deaths|PM2.5:
-    definition: Number of premature deaths associated with increased health risks from
+    description: Number of premature deaths associated with increased health risks from
       exposure to air pollution of fine particles with a diameter of 2.5 μm or less (PM2.5)
     sdg: 3
     unit: million
 - Health|Disability-Adjusted Life Years|PM2.5:
-    definition: Disability adjusted life years lost per year from health impacts
+    description: Disability adjusted life years lost per year from health impacts
       due to air pollution of fine particles with a diameter of 2.5 μm or less (PM2.5)
     sdg: 3
     unit: DALY/yr
     shape: Disability-Adjusted Life Year|PM2.5
 - Health|Child Mortality:
-    definition: Child mortality
+    description: Child mortality
     sdg: 3
     unit: million
     shape: Population|Child Mortality
 - Health|Child Mortality|Indoor Air Pollution:
-    definition: Child mortality associated with indoor air pollution
+    description: Child mortality associated with indoor air pollution
     sdg: 3
     unit: million
     shape: Population|Child Mortality|Indoor Air Pollution
 - Population|Without Education [Share]:
-    definition: Share of people aged 15 or older without education,
+    description: Share of people aged 15 or older without education,
       not counting those with incomplete primary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Primary Education|Leaving Cohort [Share]:
-    definition: Share of school-leaving cohort aged 15-19 completing primary education
+    description: Share of school-leaving cohort aged 15-19 completing primary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Secondary Education|Leaving Cohort [Share]:
-    definition: Share of school-leaving cohort aged 20-24 completing secondary education
+    description: Share of school-leaving cohort aged 20-24 completing secondary education
       (lower secondary or above)
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Adults|Without Secondary Education [Share]:
-    definition: Share of adults aged 20+ without secondary education
+    description: Share of adults aged 20+ without secondary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Gender Education Gap|Primary:
-    definition: Difference of percentage of males and females in school-leaving cohort
+    description: Difference of percentage of males and females in school-leaving cohort
       aged 15-19 with at least primary education
     sdg: 5
     unit: percentage points
     skip-region-aggregation: true
 - Population|Gender Education Gap|Secondary:
-    definition: Difference of percentage of males and females in school-leaving cohort
+    description: Difference of percentage of males and females in school-leaving cohort
       aged 20-24 with at least lower secondary education
     sdg: 5
     unit: percentage points
     skip-region-aggregation: true
 - Gender Inequality Index:
-    definition: Geometric average of reproductive health, empowerment and labor market
+    description: Geometric average of reproductive health, empowerment and labor market
       force participation rate (see Andrijevic et al., 2020)
     sdg: 5
     unit:
     weight: Population
 - Population|Severe Water Stress:
-    definition: Number of people living in areas with severe water stress
+    description: Number of people living in areas with severe water stress
     sdg: 6
     unit: million
 - Pollution|Nitrogen|Surplus|{Nitrogen Sources}:
@@ -158,123 +158,123 @@
     unit: Tg N/yr
     shape: Nitrogen|Pollution|Surplus|{Nitrogen Sources}
 - Water Quality|Nitrogen Concentration:
-    definition: Concentration of nitrogen in water at river mouths
+    description: Concentration of nitrogen in water at river mouths
     sdg: 6
     unit: mg N/l
 - Water Quality|Phosphorus Concentration:
-    definition: Concentration of phosphorus in water at river mouths
+    description: Concentration of phosphorus in water at river mouths
     sdg: 6
     unit: mg P/l
 - Freshwater|Environmental Flow Violations:
-    definition: Water withdrawals at the expense of environmental flow requirements
+    description: Water withdrawals at the expense of environmental flow requirements
     sdg: 6
     unit: km3/yr
 - Useful Energy|Transportation|Passenger [per capita]:
-    definition: Useful energy per capita for passenger transport
+    description: Useful energy per capita for passenger transport
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
 - Useful Energy|Industry [per capita]:
-    definition: Useful energy per capita for industry
+    description: Useful energy per capita for industry
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
 - Useful Energy|Residential and Commercial [per capita]:
-    definition: Useful energy per capita for buildings
+    description: Useful energy per capita for buildings
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
 - Energy Service|Passenger|Road:
-    definition: Energy service demand for passenger transport on roads
+    description: Energy service demand for passenger transport on roads
     sdg: 7
     unit: billion pkm/yr
 - Energy Service|Transportation|Passenger|Active Transport [Share]:
-    definition: Shae of walking and cycling in passenger transport
+    description: Shae of walking and cycling in passenger transport
     sdg: 7
     unit: '%'
     skip-region-aggregation: true
 #     weight: Energy Service|Transportation|Passenger
     shape: Energy Service|Transportation|Passenger|ActiveTransport|Share
 - Energy Service|Transportation|Passenger|Public Transport [Share]:
-    definition: Share of public transit in passenger transport
+    description: Share of public transit in passenger transport
     sdg: 7
     unit: '%'
     skip-region-aggregation: true
 #     weight: Energy Service|Transportation|Passenger
     shape: Energy Service|Transportation|Passenger|PublicTransport|Share
 - Energy Service|Residential|Cooling Degree Days:
-    definition: Measure of how hot the temperature was over a given period
+    description: Measure of how hot the temperature was over a given period
       indicating higher energy needs for cooling
     sdg: 7
     unit: °C-days
     skip-region-aggregation: true
 #     weight: Energy Service|Residential|Floor Space
 - Energy Service|Residential|Heating Degree Days:
-    definition: Measure of how cold the temperature was over a given period
+    description: Measure of how cold the temperature was over a given period
       indicating higher energy needs for heating
     sdg: 7
     unit: °C-days
     skip-region-aggregation: true
 #     weight: Energy Service|Residential|Floor Space
 - Final Energy|Industry|Electricity [Share]:
-    definition: Share of electricity in final energy demand for industry
+    description: Share of electricity in final energy demand for industry
     sdg: 7
     unit: '%'
     weight: Final Energy|Industry|Electricity
     shape: Final Energy|Industry|Electricity|Share
 - Intensity|Final Energy:
-    definition: Final Energy intensity
+    description: Final Energy intensity
     sdg: 7
     unit: EJ/billion USD_2010
     weight: GDP|PPP
 - GDP|PPP [Growth Rate per capita]:
-    definition: Annual growth rate of GDP-per-capita (PPP)
+    description: Annual growth rate of GDP-per-capita (PPP)
     sdg: 8
     unit: '%'
     weight: GDP|PPP
     shape: GDPpcap|PPP|Growth rate
 - GDP|PPP [per capita relative to OECD]:
-    definition: Ratio of GDP-per-capita (PPP) relative to OECD average
+    description: Ratio of GDP-per-capita (PPP) relative to OECD average
     sdg: 8
     unit: '%'
     weight: Population
     shape: GDPpcap|PPP|Ratio to OECD
 - Population|Poverty|National Poverty Line [Share]:
-    definition: Share of population living in relative poverty with income below their
+    description: Share of population living in relative poverty with income below their
       respective national poverty lines
     sdg: 10
     unit: '%'
     weight: Population
     shape: Population|Relative Poverty|Share
 - Population|Poverty|Below 50% of National Median Income [Share]:
-    definition: Share of population below 50% of median national income
+    description: Share of population below 50% of median national income
     sdg: 10
     unit: '%'
     weight: Population
     shape: Population|Relative poverty|wrt median income|Share
 - Inequality|Average Income|Bottom 40% [Ratio]:
-    definition: Average income of bottom 40% of population relative to national average
+    description: Average income of bottom 40% of population relative to national average
     sdg: 10
     unit: '%'
     weight: Population
     shape: Inequality|Bottom 40% average income|Ratio
 - Population|Informal Settlements:
-    definition: Number of people living in informal settlements, e.g., slums
+    description: Number of people living in informal settlements, e.g., slums
     sdg: 11
     unit: million
 - Population|Substandard Accommodation:
-    definition: Number of people living in substandard accommodation, e.g., accommodation
+    description: Number of people living in substandard accommodation, e.g., accommodation
       that does not meet legal requirements and/or enable well being for the occupants
     sdg: 11
     unit: million
     shape: Population|substandard accommodation
 - Population|Urban [Share]:
-    definition: Share of population living in urban areas
+    description: Share of population living in urban areas
     sdg: 11
     unit: '%'
     weight: Population
 - Air Pollution|PM2.5|Urban Population:
-    definition: Urban population weighted annual average PM2.5 concentrations.
+    description: Urban population weighted annual average PM2.5 concentrations.
     sdg: 11
     unit: ug/m3
     weight: Population|Urban
@@ -291,127 +291,127 @@
 #     weight: Production|Iron and Steel|Volume
     shape: Material recycling|{Recycled Materials}|Share
 - Agricultural Material Footprint [per capita]:
-    definition: Biomass usage per capita excluding pasture and forestry
+    description: Biomass usage per capita excluding pasture and forestry
     sdg: 12
     unit: tDM/cap/yr
     weight: Population
     shape: Agricultural Material Footprint
 - Food Waste [per capita]:
-    definition: Amount of food (crops and livestock) per capita that is disposed
+    description: Amount of food (crops and livestock) per capita that is disposed
       and not consumed
     unit: kcal/cap/day
     weight: Population
 - Ocean|Acidification:
-    definition: Ocean acidification
+    description: Ocean acidification
     sdg: 14
     unit: pH
     skip-region-aggregation: true
     shape: Ocean|pH value
 - Ocean|Carbonate Saturation|Aragonite:
-    definition: Saturation state of aragonite (Omega A)
+    description: Saturation state of aragonite (Omega A)
     sdg: 14
     unit:
     skip-region-aggregation: true
 - Ocean|Carbonate Saturation|Calcite:
-    definition: Saturation state of calcite (Omega C)
+    description: Saturation state of calcite (Omega C)
     sdg: 14
     unit:
     skip-region-aggregation: true  
 - Land Cover|Forest|Natural Forest|Primary Forest:
-    definition: Undisturbed primary natural forests
+    description: Undisturbed primary natural forests
     sdg: 15
     unit: million ha   
 - Land Cover|Forest|Natural Forest|Secondary Forest:
-    definition: Modified natural forests and secondary forests from natural succession
+    description: Modified natural forests and secondary forests from natural succession
     sdg: 15
     unit: million ha      
 - Terrestrial Biodiversity|MSA:
-    definition: Terrestrial biodiversity measured in Mean Species Abundance (MSA)
+    description: Terrestrial biodiversity measured in Mean Species Abundance (MSA)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 #     weight: Land Cover
 - Terrestrial Biodiversity|BII|Cropland Landscapes:
-    definition: Terrestrial biodiversity in landscapes containing cropland measured
+    description: Terrestrial biodiversity in landscapes containing cropland measured
       with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 #     weight: Land Cover|Cropland
 - Terrestrial Biodiversity|BII|Biodiversity Hotspots:
-    definition: Terrestrial biodiversity in biodiversity hotspot landscapes measured
+    description: Terrestrial biodiversity in biodiversity hotspot landscapes measured
       with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|BII|Key Conservation Landscapes:
-    definition: Terrestrial biodiversity in biodiversity hotspot and intact forest landscapes
+    description: Terrestrial biodiversity in biodiversity hotspot and intact forest landscapes
       measured with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|BII|Areas Outside Key Conservation and Cropland Landscapes:
-    definition: Terrestrial biodiversity in areas outside biodiversity hotspot,
+    description: Terrestrial biodiversity in areas outside biodiversity hotspot,
       intact forest & cropland landscapes measured with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
 - Terrestrial Biodiversity|Shannon Crop Diversity Index:
-    definition: Crop diversity measured by the Shannon index accounting for crop richness
+    description: Crop diversity measured by the Shannon index accounting for crop richness
       and abundance
     sdg: 15
     unit: index
     skip-region-aggregation: true
 #     weight: Land Cover|Cropland
 - Nitrogen|Cropland Budget|Inputs:
-    definition: Total nitrogen inputs on cropland
+    description: Total nitrogen inputs on cropland
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Industrial and Intentional Biological Fixation:
-    definition: Nitrogen inputs on cropland via industrial and intentional biological fixation
+    description: Nitrogen inputs on cropland via industrial and intentional biological fixation
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Biological Fixation:
-    definition: Nitrogen inputs on cropland from biological fixation (symbiotic crops and free-living bacteria)
+    description: Nitrogen inputs on cropland from biological fixation (symbiotic crops and free-living bacteria)
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Biological Fixation|Symbiotic Crops:
-    definition: Nitrogen inputs on cropland from symbiotic fixation in plants
+    description: Nitrogen inputs on cropland from symbiotic fixation in plants
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Organic:
-    definition: Nitrogen inputs on cropland from organic fertilizers
+    description: Nitrogen inputs on cropland from organic fertilizers
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Inorganic:
-    definition: Nitrogen inputs on cropland from inorganic fertilizers
+    description: Nitrogen inputs on cropland from inorganic fertilizers
     sdg: 15
     unit: Tg N/yr
 - Nitrogen|Cropland Budget|Inputs|Other:
-    definition: Nitrogen inputs on cropland from other sources
+    description: Nitrogen inputs on cropland from other sources
     sdg: 15
     unit: Tg N/yr
 - Political Institutions|Equality Before Law and Individual Liberty:
-    definition: Aggregated 'Equality Before the Law and Individual Liberty' index (0-1)
+    description: Aggregated 'Equality Before the Law and Individual Liberty' index (0-1)
       as defined by V-DEM
     sdg: 16
     unit:
     weight: Population
     shape: Political Institutions|Equality before law and individual liberty
 - Price|Carbon [relative to OECD]:
-    definition: Carbon price relative to OECD carbon price
+    description: Carbon price relative to OECD carbon price
     sdg: 17
     unit: '%'
     skip-region-aggregation: true
     shape: Price|Carbon|Ratio to OECD
 - Policy Cost|GDP Loss w/o Transfers:
-    definition: GDP loss without international transfers in a policy scenario compared
+    description: GDP loss without international transfers in a policy scenario compared
       to the corresponding baseline (losses should be reported as positive numbers)
     sdg: 17
     unit: billion USD_2010/yr
     shape: Policy Cost|GDP Loss|w/o transfers
 - Policy Cost|Transfers:
-    definition: Net international climate finance transfers (positive for inflow,
+    description: Net international climate finance transfers (positive for inflow,
       negative for payment)
     sdg: 17
     unit: billion USD_2010/yr

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -257,17 +257,19 @@
     definition:
     sdg: 9
     unit: billion US$2010
-- Population|Relative Poverty [Share]:
+- Population|Poverty|National Poverty Line [Share]:
     definition: Share of population living in relative poverty with income below their
-      respective national poverty lines.
+      respective national poverty lines
     sdg: 10
     unit: '%'
     weight: Population
-- Population|Relative poverty|wrt median income [Share]:
+    shape: Population|Relative Poverty|Share
+- Population|Poverty|Below 50% of National Median Income [Share]:
     definition: Share of population below 50% of median national income
     sdg: 10
     unit: '%'
     weight: Population
+    shape: Population|Relative poverty|wrt median income|Share
 - Inequality|Bottom 40% average income [Ratio]:
     definition: Average income of bottom 40% relative to national average
     sdg: 10

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -87,24 +87,27 @@
     unit: Index (2020 = 1)
     skip-region-aggregation: true
 #     weight: Agricultural Production|Non-Energy
-- Premature Deaths|PM2.5:
-    definition: Premature deaths associated with increase health risks from exposure
-      to PM2.5 air pollution
+- Health|Premature Deaths|PM2.5:
+    definition: Number of premature deaths associated with increased health risks from
+      exposure to air pollution of fine particles with a diameter of 2.5 μm or less (PM2.5)
     sdg: 3
     unit: million
-- Disability-Adjusted Life Year|PM2.5:
-    definition: Disability adjusted life years lost per year from air pollution health
-      impact
+- Health|Disability-Adjusted Life Years|PM2.5:
+    definition: Disability adjusted life years lost per year from health impacts
+      due to air pollution of fine particles with a diameter of 2.5 μm or less (PM2.5)
     sdg: 3
     unit: DALY/yr
-- Population|Child Mortality:
+    shape: Disability-Adjusted Life Year|PM2.5
+- Health|Child Mortality:
     definition: Child mortality
     sdg: 3
     unit: million
-- Population|Child Mortality|Indoor Air Pollution:
+    shape: Population|Child Mortality
+- Health|Child Mortality|Indoor Air Pollution:
     definition: Child mortality associated with indoor air pollution
     sdg: 3
     unit: million
+    shape: Population|Child Mortality|Indoor Air Pollution
 - Population|Without Education [Share]:
     definition: Share of people aged 15 or older without education (not counting those
       with incomplete primary education)

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -62,17 +62,12 @@
     sdg: 2
     unit: million
 - Food|Availability [per capita]:
-    definition: Food available for consumption per capita
+    definition: Amount of food available for consumption per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
-- Food|Availability|Crops [per capita]:
-    definition: Food crops available for consumption per capita
-    sdg: 2
-    unit: kcal/cap/day
-    weight: Population
-- Food|Availability|Livestock [per capita]:
-    definition: Livestock products available for consumption per capita
+- Food|Availability|{Food Options} [per capita]:
+    definition: Amount of {Food Options} available for consumption per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population
@@ -81,13 +76,8 @@
     sdg: 2
     unit: kcal/cap/day
     weight: Population
-- Food|Intake|Crops [per capita]:
-    definition: Calorie intake from food crops per capita
-    sdg: 2
-    unit: kcal/cap/day
-    weight: Population
-- Food|Intake|Livestock [per capita]:
-    definition: Calorie intake from livestock products per capita
+- Food|Intake|{Food Options} [per capita]:
+    definition: Calorie intake of {Food Options} per capita
     sdg: 2
     unit: kcal/cap/day
     weight: Population

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -14,6 +14,23 @@
       below USD_2011 5.50 PPP per day (World Bank LMIC definition)
     sdg: 1
     unit: million
+- Population|Risk of Hunger:
+    definition: Population at risk of hunger, calculated by multipling total population
+      and prevalence of undernourishment which is computed from a probability distribution
+      of daily dietary energy consumption and minimum dietary energy requirement.
+    unit: million
+- Population|Electricity Access:
+    definition: Population with access to electricity
+    unit: million
+- Population|Relying on Solid Fuels:
+    definition: Population without access to electricity and relying on solid fuels
+      for heating-cooking
+    unit: million
+- Population|Clean Cooking Access:
+    definition: Population with access to improved cooking facilities (electric or
+      gas)
+    unit: million
+    navigate: Population|Clean cooking Access
 - Expenditure|Households|Food [Share]:
     description: Share of food expenditure in total income
     sdg: 1
@@ -184,12 +201,28 @@
     sdg: 7
     unit: GJ/cap/yr
     weight: Population
-- Energy Service|Passenger|Road:
+- Useful Energy|Residential [per capita]:
+    description: Useful energy per capita for buildings
+    sdg: 7
+    unit: GJ/cap/yr
+    weight: Population
+- Useful Energy|Commercial [per capita]:
+    description: Useful energy per capita for buildings
+    sdg: 7
+    unit: GJ/cap/yr
+    weight: Population
+- Energy Service|Transportation|Freight:
+    definition: Energy service demand for freight transport
+    unit: billion tkm/yr
+- Energy Service|Transportation|Passenger:
+    definition: Energy service demand for passenger transport
+    unit: billion pkm/yr
+- Energy Service|Transportation|Passenger|Road:
     description: Energy service demand for passenger transport on roads
     sdg: 7
     unit: billion pkm/yr
 - Energy Service|Transportation|Passenger|Active Transport [Share]:
-    description: Shae of walking and cycling in passenger transport
+    description: Share of walking and cycling in passenger transport
     sdg: 7
     unit: '%'
     skip-region-aggregation: true
@@ -316,7 +349,14 @@
     description: Saturation state of calcite (Omega C)
     sdg: 14
     unit:
-    skip-region-aggregation: true  
+    skip-region-aggregation: true
+- Land Cover:
+    definition: total land cover
+    unit: million ha
+- Land Cover|Cropland:
+    definition: total arable land, i.e. land in bioenergy crop, food, and feed/fodder
+      crops, permant crops as well as other arable land (physical area)
+    unit: million ha
 - Land Cover|Forest|Natural Forest|Primary Forest:
     description: Undisturbed primary natural forests
     sdg: 15
@@ -330,14 +370,29 @@
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
-#     weight: Land Cover
+    weight: Land Cover
+- Terrestrial Biodiversity|MSA|Vertebrates:
+    definition: Terrestrial biodiversity of vertebrate species measured in Mean Species
+      Abundance (MSA)
+    unit: '%'
+    weight: Land Cover
+- Terrestrial Biodiversity|MSA|Plants:
+    definition: Terrestrial biodiversity of plant species measured in Mean Species
+      Abundance (MSA)
+    unit: '%'
+    weight: Land Cover
+- Terrestrial Biodiversity|BII:
+    definition: Terrestrial biodiversity measured with Biodiversity Intactness Index
+      (BII)
+    unit: '%'
+    weight: Land Cover
 - Terrestrial Biodiversity|BII|Cropland Landscapes:
     description: Terrestrial biodiversity in landscapes containing cropland measured
       with Biodiversity Intactness Index (BII)
     sdg: 15
     unit: '%'
     skip-region-aggregation: true
-#     weight: Land Cover|Cropland
+    weight: Land Cover|Cropland
 - Terrestrial Biodiversity|BII|Biodiversity Hotspots:
     description: Terrestrial biodiversity in biodiversity hotspot landscapes measured
       with Biodiversity Intactness Index (BII)
@@ -415,3 +470,9 @@
       negative for payment)
     sdg: 17
     unit: billion USD_2010/yr
+- Unemployment:
+    definition: Number of unemployed inhabitants (based on ILO classification)
+    unit: million
+- Unemployment [Rate]: 
+    definition: Fraction of unemployed inhabitants (based on ILO classification)
+    unit: '%'

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -277,36 +277,17 @@
     unit: ug/m3
     weight: Population|Urban
     shape: Air Pollution|PM2.5|Urban population
-- Material Recycling|Chemicals:
-    definition: Production of Recycled Chemicals
+- Material Recycling|{Recycled Materials}:
+    description: Production of recycled {Recycled Materials}
     sdg: 12
     unit: Mt/year
-- Material Recycling|Steel:
-    definition: Production of Recycled Steel
-    sdg: 12
-    unit: Mt/year
-- Material Recycling|Aluminum:
-    definition: Production of Recycled Aluminum
-    sdg: 12
-    unit: Mt/year
-- Material recycling|Steel [Share]:
-    definition: Share of Recycled Steel
+- Material Recycling|{Recycled Materials} [Share]:
+    description: Share of recycled {Recycled Materials}
     sdg: 12
     unit: '%'
     skip-region-aggregation: true
 #     weight: Production|Iron and Steel|Volume
-- Material recycling|Aluminum [Share]:
-    definition: Share of Recycled Aluminum
-    sdg: 12
-    unit: '%'
-    skip-region-aggregation: true
-#     weight: Production|Non-Ferrous Metals|Aluminium|Volume
-- Material recycling|Plastic [Share]:
-    definition: Share of Recycled Plastic
-    sdg: 12
-    unit: '%'
-    skip-region-aggregation: true
-#     weight: Production|Chemicals|Plastics|Volume
+    shape: Material recycling|{Recycled Materials}|Share
 - Agricultural Material Footprint [per capita]:
     definition: Biomass usage per capita (excluding pasture + forestry)
     sdg: 12

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -203,13 +203,15 @@
 #     weight: Energy Service|Transportation|Passenger
     shape: Energy Service|Transportation|Passenger|PublicTransport|Share
 - Energy Service|Residential|Cooling Degree Days:
-    definition:
+    definition: Measure of how hot the temperature was over a given period
+      indicating higher energy needs for cooling
     sdg: 7
     unit: °C-days
     skip-region-aggregation: true
 #     weight: Energy Service|Residential|Floor Space
 - Energy Service|Residential|Heating Degree Days:
-    definition:
+    definition: Measure of how cold the temperature was over a given period
+      indicating higher energy needs for heating
     sdg: 7
     unit: °C-days
     skip-region-aggregation: true

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -82,7 +82,7 @@
     unit: kcal/cap/day
     weight: Population
 - Price|Agriculture|Livestock|Index:
-    definition: weighted average price index of livestock
+    definition: Weighted average price index of livestock
     sdg: 2
     unit: Index (2020 = 1)
     skip-region-aggregation: true
@@ -109,47 +109,47 @@
     unit: million
     shape: Population|Child Mortality|Indoor Air Pollution
 - Population|Without Education [Share]:
-    definition: Share of people aged 15 or older without education (not counting those
-      with incomplete primary education)
+    definition: Share of people aged 15 or older without education,
+      not counting those with incomplete primary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Primary Education|Leaving Cohort [Share]:
-    definition: Share of school-leaving cohort ( age group 15-19) completing primary
-      education
+    definition: Share of school-leaving cohort aged 15-19 completing primary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Secondary Education|Leaving Cohort [Share]:
-    definition: Share of school-leaving cohort (age group 20-24) completing secondary
-      education (lower secondary or above)
+    definition: Share of school-leaving cohort aged 20-24 completing secondary education
+      (lower secondary or above)
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Adults|Without Secondary Education [Share]:
-    definition: Share of adults (age 20+) without secondary education
+    definition: Share of adults aged 20+ without secondary education
     sdg: 4
     unit: '%'
     weight: Population
 - Population|Gender Education Gap|Primary:
     definition: Difference of percentage of males and females in school-leaving cohort
-      (age 15-19) with at least primary education
+      aged 15-19 with at least primary education
     sdg: 5
     unit: percentage points
     skip-region-aggregation: true
 - Population|Gender Education Gap|Secondary:
     definition: Difference of percentage of males and females in school-leaving cohort
-      (age 20-24) with at least lower secondary education
+      aged 20-24 with at least lower secondary education
     sdg: 5
     unit: percentage points
     skip-region-aggregation: true
 - Gender Inequality Index:
-    definition: Andrijevic et al. 2020
+    definition: Geometric average of reproductive health, empowerment and labor market
+      force participation rate (see Andrijevic et al., 2020)
     sdg: 5
-    unit: '-'
+    unit:
     weight: Population
 - Population|Severe Water Stress:
-    definition: number of people living in areas with severe water stress
+    definition: Number of people living in areas with severe water stress
     sdg: 6
     unit: million
 - Nitrogen|Pollution|Surplus|Animal Waste Management:

--- a/definitions/variable/sdg-indicators/tag_food.yaml
+++ b/definitions/variable/sdg-indicators/tag_food.yaml
@@ -1,0 +1,5 @@
+- Food Options:
+    - Crops:
+        description: food crops
+    - Livestock:
+        description: livestock products

--- a/definitions/variable/sdg-indicators/tag_nitrogen-sources.yaml
+++ b/definitions/variable/sdg-indicators/tag_nitrogen-sources.yaml
@@ -1,0 +1,10 @@
+- Nitrogen Sources:
+    - Animal Waste Managementps:
+        description: animal waste management
+    - Cropland:
+        description: soil inputs over soil withdrawals in cropland
+    - Non-Agricultural Land:
+        description: non-agricultural land
+        shape: Non-agricultural land
+    - Pasture:
+        description: soil inputs over soil withdrawals in pasture

--- a/definitions/variable/sdg-indicators/tag_nitrogen-sources.yaml
+++ b/definitions/variable/sdg-indicators/tag_nitrogen-sources.yaml
@@ -1,5 +1,5 @@
 - Nitrogen Sources:
-    - Animal Waste Managementps:
+    - Animal Waste Management:
         description: animal waste management
     - Cropland:
         description: soil inputs over soil withdrawals in cropland

--- a/definitions/variable/sdg-indicators/tag_recycled-materials.yaml
+++ b/definitions/variable/sdg-indicators/tag_recycled-materials.yaml
@@ -1,0 +1,9 @@
+- Recycled Materials:
+    - Chemicals:
+        description: chemicals
+    - Plastics:
+        description: plastics
+    - Steel:
+        description: steel
+    - Aluminum:
+        description: aluminum


### PR DESCRIPTION
This PR copies the PR #53 and implements a number of clean-ups (given that @bs538 indicated he could not work on this over the next weeks).

See the list of commits for a clean step-by-step reporting of the changes that I implemented beyond the work done so far, trying to implement a consistent variable-naming and use of units.

A few open questions:
- what are the right units for ocean saturation?
- would it make sense to spell out MSA and BII in the variable names for clarity and readability
- why are the nitrogen variables named "Cropland Budget", and how is that related to nitrogen?
- what is V-DEM? (in the description of the indicator "Equality Before Law and Individual Liberty"

Related issues: #72 #62 

FYI @IAMconsortium/common-definitions-sdg-indicators 