### PR TITLE
add CCS to cmanagement definitions

### DIFF
--- a/definitions/variable/emissions/tag_carbon-management.yaml
+++ b/definitions/variable/emissions/tag_carbon-management.yaml
@@ -7,6 +7,8 @@
         description: production of biochar using pyrolysis
     - Direct Air Capture:
         description: direct air capture
+    - Carbon Capture and Storage:
+        description: the capture from point sources, including distribution and ultimate storage
     - Enhanced Weathering:
         description: terrestrial application of alkalinity to increase CO2 uptake on land
     - Direct Ocean Capture:

--- a/definitions/variable/emissions/tag_carbon-management.yaml
+++ b/definitions/variable/emissions/tag_carbon-management.yaml
@@ -3,12 +3,13 @@
 
 # This list should be a subset of carbon-removal options in definitions/variable/emissions/carbon-removal.yaml
 - Carbon Management Technology:
+    - Carbon Capture and Storage:
+        description: the capture from point sources, including distribution and sequestration
+          in geological storage
     - Biochar:
         description: production of biochar using pyrolysis
     - Direct Air Capture:
         description: direct air capture
-    - Carbon Capture and Storage:
-        description: the capture from point sources, including distribution and ultimate storage
     - Enhanced Weathering:
         description: terrestrial application of alkalinity to increase CO2 uptake on land
     - Direct Ocean Capture:


### PR DESCRIPTION
FYI @strefler @jayfuhrman @danielhuppmann 

Are we ok with just one FE CCS variable? There is a bit of overlap with DAC here. I would say energy for purely the capture of DAC go into the DAC variable, but transportation and storage energy (if modeled) go into CCS. 