### PR TITLE
Guard against methods-terms as sub-categories

### DIFF
--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -98,12 +98,12 @@
     sdg: 2
     unit: kcal/cap/day
     weight: Population
-- Price|Agriculture|Livestock|Index:
+- Price|Agriculture|Livestock [Index]:
     description: Weighted average price index of livestock
     sdg: 2
     unit: Index (2020 = 1)
     skip-region-aggregation: true
-#     weight: Agricultural Production|Non-Energy
+    shape: Price|Agriculture|Livestock|Index
 - Health|Premature Deaths|PM2.5:
     description: Number of premature deaths associated with increased health risks from
       exposure to air pollution of fine particles with a diameter of 2.5 μm or less (PM2.5)

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,5 +1,7 @@
 from nomenclature import DataStructureDefinition
 
+LEGACY_PROJECTS = ["navigate", "engage", "shape"]
+
 
 def test_legacy_variables():
     # Check that (new) variables are not referenced as deprecated legacy variables
@@ -8,7 +10,7 @@ def test_legacy_variables():
 
     legacy_variables = {}
     for code, attrs in dsd.variable.items():
-        for project in ["navigate", "engage"]:
+        for project in LEGACY_PROJECTS:
             if project in attrs.extra_attributes:
                 legacy_var = attrs.__getattr__(project)
                 if legacy_var in existing_variables:

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -8,9 +8,9 @@ def test_variable_ops_as_square_brackets():
     dsd = DataStructureDefinition("definitions/", dimensions=["variable"])
 
     error = []
-    for variable, attrs in dsd.variable.items():
+    for variable in dsd.variable:
         if reserved_terms := [r for r in ["Index", "Share"] if "|" + r in variable]:
-            error.append(f"Variable '{variable}' -> '[{''.join(reserved_terms)}]'")
+            error.append(f"Variable '{variable}' -> '... [{''.join(reserved_terms)}]'")
     if error:
         raise ValueError(
             f"Found reserved terms in the following variables:\n{'\n - '.join(error)}"

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -1,7 +1,7 @@
 from nomenclature import DataStructureDefinition
 
 
-def test_legacy_variables():
+def test_variable_ops_as_square_brackets():
     # Check that variables use square brackets for operations
     # https://github.com/IAMconsortium/common-definitions/issues/55
 

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -10,9 +10,7 @@ def test_legacy_variables():
     error = []
     for variable, attrs in dsd.variable.items():
         if reserved_terms := [r for r in ["Index", "Share"] if "|" + r in variable]:
-            error.append(
-                f"Variable '{variable}' -> '[{''.join(reserved_terms)}]'"
-            )
+            error.append(f"Variable '{variable}' -> '[{''.join(reserved_terms)}]'")
     if error:
         raise ValueError(
             f"Found reserved terms in the following variables:\n{'\n - '.join(error)}"

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -1,5 +1,7 @@
 from nomenclature import DataStructureDefinition
 
+RESERVED_TERMS = ["Index", "Share", "Value", "Volume"]
+
 
 def test_variable_ops_as_square_brackets():
     # Check that variables use square brackets for operations
@@ -9,7 +11,7 @@ def test_variable_ops_as_square_brackets():
 
     error = []
     for variable in dsd.variable:
-        if reserved_terms := [r for r in ["Index", "Share"] if "|" + r in variable]:
+        if reserved_terms := [r for r in RESERVED_TERMS if "|" + r in variable]:
             error.append(f"Variable '{variable}' -> '... [{''.join(reserved_terms)}]'")
     if error:
         raise ValueError(

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -3,6 +3,10 @@ from nomenclature import DataStructureDefinition
 RESERVED_TERMS = ["Index", "Share", "Value", "Volume"]
 
 
+# TODO: Move this test to the nomenclature `validate-project` utility
+# see https://github.com/IAMconsortium/nomenclature/issues/341
+
+
 def test_variable_ops_as_square_brackets():
     # Check that variables use square brackets for operations
     # https://github.com/IAMconsortium/common-definitions/issues/55

--- a/tests/test_reserved_terms.py
+++ b/tests/test_reserved_terms.py
@@ -1,0 +1,19 @@
+from nomenclature import DataStructureDefinition
+
+
+def test_legacy_variables():
+    # Check that variables use square brackets for operations
+    # https://github.com/IAMconsortium/common-definitions/issues/55
+
+    dsd = DataStructureDefinition("definitions/", dimensions=["variable"])
+
+    error = []
+    for variable, attrs in dsd.variable.items():
+        if reserved_terms := [r for r in ["Index", "Share"] if "|" + r in variable]:
+            error.append(
+                f"Variable '{variable}' -> '[{''.join(reserved_terms)}]'"
+            )
+    if error:
+        raise ValueError(
+            f"Found reserved terms in the following variables:\n{'\n - '.join(error)}"
+        )


### PR DESCRIPTION
In #55, we agreed to use square brackets to identify methods or operations, e.g. `... [Share]` instead of the previously used subcategories like `...|Share`.

This PR adds a test to guard against adding subcategory-methods-variables in the future and renames one variable from the SDG domain.

fyi @IAMconsortium/common-definitions-sdg-indicators 