### PR TITLE
Add explicit list of components of emissions

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -5,6 +5,12 @@
 - Emissions|{Level-1 Species}:
     description: Emissions of {Level-1 Species}
     unit: "{Level-1 Species}"
+    components:
+      - Emissions|{Level-1 Species}|AFOLU
+      - Emissions|{Level-1 Species}|Energy
+      - Emissions|{Level-1 Species}|Industrial Processes
+      - Emissions|{Level-1 Species}|Waste
+      - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
     definition: Gross emissions of carbon dioxide (CO2), not accounting for negative
       emissions from bioenergy with CCS (BECCS) or agriculture, forestry
@@ -49,12 +55,18 @@
       including emissions from international bunker fuels, net of negative emissions
       from bioenergy with CCS (BECCS) in these sectors
     unit: "{Level-3 Species}"
+    components:
+      - Emissions|{Level-3 Species}|Energy
+      - Emissions|{Level-3 Species}|Industrial Processes
 - Gross Emissions|CO2|Energy and Industrial Processes:
     definition: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
       including emissions from international bunker fuels, not accounting for
       negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
+    components:
+      - Gross Emissions|CO2|Energy
+      - Gross Emissions|CO2|Industrial Processes
 
 - Emissions|{Level-2 Species}|Energy:
     description: Emissions of {Level-2 Species} from energy use,
@@ -130,7 +142,7 @@
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
-     not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}


### PR DESCRIPTION
This PR adds the list of components for several emissions-variables (where the value is *not* just the sum of sub-components because of the "Energy and Industrial Processes" auxiliary-reporting category.

This list of components is not yet correctly resolved  by **nomenclature** (tags are not replaced and checked against the codelist if they are in a list), but it could still be useful to have this information here as an example for future use.

fyi @IAMconsortium/common-definitions-emissions 