### PR TITLE
Harmonize unemployment rate variable

### DIFF
--- a/definitions/variable/macro-economy/labor-force.yaml
+++ b/definitions/variable/macro-economy/labor-force.yaml
@@ -12,3 +12,8 @@
     unit: million
     tier: 1
     min: 0
+- Labor Force|Unemployment [Rate]:
+    definition: Fraction of unemployed inhabitants (based on ILO classification)
+    unit: '%'
+    range: 0, 100
+    navigate: Unemployment|Rate

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -473,6 +473,3 @@
       negative for payment)
     sdg: 17
     unit: billion USD_2010/yr
-- Unemployment [Rate]: 
-    definition: Fraction of unemployed inhabitants (based on ILO classification)
-    unit: '%'


### PR DESCRIPTION
For harmonization with #94, this PR refactors the variable "Unemployment|Rate" (from NAVIGATE) to "Labour Force|Unemployment [Rate]" for consistency with the changes to the variables "Employment" and "Unemployment". The variable is also moved from the SDG section to the macro-economy folder for consistency.

FYI @bs538 @FlorianLeblancDr