### PR TITLE
Proposal for for data validation syntax

### DIFF
--- a/validation/data_emissions.yaml
+++ b/validation/data_emissions.yaml
@@ -1,0 +1,22 @@
+# validation bounds for historical CO2 emissions
+- CO2 emissions data:
+    variable: Emissions|CO2|Energy and Industrial Processes
+    World:
+      region: World
+      2015:
+        year: 2015
+        # 36320 MtCO2 in 2015 per Global Carbon Budget (2023) with 5% deviation bounds
+        upper_bound: 38136
+        lower_bound: 34504
+      2020:
+        year: 2020
+        # 35650 MtCO2 in 2020 per Global Carbon Budget (2023) with 5% deviation bounds
+        upper_bound: 37432.5
+        lower_bound: 33867.5
+    2020:
+      year: 2020
+      Asia (R5):
+        region: Asia (R5)
+        # 20520 MtCO2 in 2020 per OWID (2023) with 10% deviation bounds
+        upper_bound: 22572
+        lower_bound: 18468

--- a/validation/data_final_energy.yaml
+++ b/validation/data_final_energy.yaml
@@ -1,0 +1,3 @@
+# final energy consumption must be positive
+- variable: Final Energy
+  lower_bound: 0


### PR DESCRIPTION
This PR proposes a syntax for data validation as part of the scenario-processing infrastructure.

This PR is intended as a minimum viable product for scenario data validation. This feature is not yet supported by the [nomenclature](https://nomenclature-iamc.readthedocs.io/) package, but will be added as a new class **DataValidator** once we reach agreement about the syntax.

The proposed syntax tries to strike a balance between readability and flexibility, using a nested yaml-style syntax to define
- **filters**: variable, region, unit, year
- **bounds**: upper_bound, lower_bound

Any datapoint in an IAMC-style timeseries format matching the given filters must satisfy the bounds, otherwise an error is raised. The structure directly matches the signature of the method [IamDataFrame.validate()](https://pyam-iamc.readthedocs.io/en/stable/api/iamdataframe.html#pyam.IamDataFrame.validate) so that the implementation can build on the existing functionality.

The syntax works as follows:
- yaml files in a folder **validation** in a workflow repository
- a list of yaml dictionaries with (some of) the arguments specified above (see the final-energy prototype)
- (optional) a nested structure where arguments in the upper level (**variable** in the emissions prototype) are combined with all lower-level dictionaries (years and regions)

Going forward, we can also implement more features, including
- a keyword argument **required** 
- reading data from a csv-file format for larger collection of datapoints to be validated


