### PR TITLE
Add source-categories for secondary energy carriers

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -102,13 +102,15 @@
     description: Gross emissions of carbon dioxide (CO2) for electricity generation,
       not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
     unit: Mt CO2/yr
-- Emissions|CO2|Energy|Supply|{Secondary Fuel}:
+- Emissions|CO2|Energy|Supply|{Secondary Fuel with Source}:
     description: Emissions of carbon dioxide (CO2) for production of {Secondary Fuel}
     unit: Mt CO2/yr
-- Gross Emissions|CO2|Energy|Supply|{Secondary Fuel}:
-    description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel},
+    tier: "{Secondary Fuel with Source}"
+- Gross Emissions|CO2|Energy|Supply|{Secondary Fuel with Source}:
+    description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel with Source},
       not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
     unit: Mt CO2/yr
+    tier: "{Secondary Fuel with Source}"
 - Emissions|CO2|Energy|Supply|Autoproduction:
     description: Emissions of carbon dioxide (CO2) for own-use energy supply
     unit: Mt CO2/yr

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -13,21 +13,21 @@
 - Final Energy|Non-Energy Use:
     description: Final energy consumption in non-combustion processes
     unit: EJ/yr
-- Final Energy|Non-Energy Use|{Secondary Fuel}:
-    description: Final energy consumption of {Secondary Fuel} in non-combustion processes
+- Final Energy|Non-Energy Use|{Secondary Fuel with Source}:
+    description: Final energy consumption of {Secondary Fuel with Source} in non-combustion processes
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+    tier: "{Secondary Fuel with Source}"
 - Final Energy|Non-Energy Use|Waste:
     description: Final energy consumption of non-renewable waste in non-combustion processes
     unit: EJ/yr
 - Final Energy|Non-Energy Use|{Non-Energy Sector}:
     description: Final energy consumption by the {Non-Energy Sector} for non-combustion processes
     unit: EJ/yr
-- Final Energy|Non-Energy Use|{Non-Energy Sector}|{Secondary Fuel}:
-    description: Final energy consumption of {Secondary Fuel} by the {Non-Energy Sector}
+- Final Energy|Non-Energy Use|{Non-Energy Sector}|{Secondary Fuel with Source}:
+    description: Final energy consumption of {Secondary Fuel} by the {Non-Energy Sector with Source}
       for non-combustion processes
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+    tier: "{Secondary Fuel with Source}"
 - Final Energy|Non-Energy Use|{Non-Energy Sector}|Waste:
     description: Final energy consumption of non-renewable waste by the {Non-Energy Sector}
       for non-combustion processes
@@ -45,10 +45,10 @@
     description: Final energy consumption of electricity (including on-site solar PV),
       excluding transmission/distribution losses
     unit: EJ/yr
-- Final Energy|{Secondary Fuel}:
-    description: Final energy fuel consumption of {Secondary Fuel}
+- Final Energy|{Secondary Fuel with Source}:
+    description: Final energy fuel consumption of {Secondary Fuel with Source}
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+    tier: "{Secondary Fuel with Source}"
 - Final Energy|Geothermal:
     description: Final energy consumption of geothermal energy (e.g., from decentralized
       or small-scale geothermal heating systems) excluding geothermal heat pumps
@@ -71,10 +71,10 @@
 - Final Energy|{Sector}|Electricity:
     description: Final energy consumption by the {Sector} of electricity
     unit: EJ/yr
-- Final Energy|{Sector}|{Secondary Fuel}:
-    description: Final energy consumption by the {Sector} of {Secondary Fuel}
+- Final Energy|{Sector}|{Secondary Fuel with Source}:
+    description: Final energy consumption by the {Sector} of {Secondary Fuel with Source}
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
+    tier: "{Secondary Fuel with Source}"
 - Final Energy|{Sector}|Other:
     description: Final energy consumption by the {Sector} of other energy sources
     unit: EJ/yr
@@ -100,11 +100,11 @@
     unit: EJ/yr
     notes: See `Secondary Energy|Electricity|...` for the power generation mix
     navigate: Final Energy|Carbon Removal|Electricity
-- Final Energy|Carbon Management|{Secondary Fuel}:
-    description: Use of {Secondary Fuel} for carbon management
+- Final Energy|Carbon Management|{Secondary Fuel with Source}:
+    description: Use of {Secondary Fuel with Source} for carbon management
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
-    navigate: Final Energy|Carbon Removal|{Secondary Fuel}
+    tier: "{Secondary Fuel with Source}"
+    navigate: Final Energy|Carbon Removal|{Secondary Fuel with Source}
 - Final Energy|Carbon Management|Other:
     description: Use of other energy sources for carbon management
     unit: EJ/yr
@@ -117,12 +117,12 @@
     notes: See `Secondary Energy|Electricity|...` for the power generation mix
     navigate: Final Energy|Carbon Removal|Electricity|{Carbon Management Technology}
     engage: Final Energy|Carbon Removal|Electricity|{Carbon Management Technology}
-- Final Energy|Carbon Management|{Carbon Management Technology}|{Secondary Fuel}:
+- Final Energy|Carbon Management|{Carbon Management Technology}|{Secondary Fuel with Source}:
     description: Use of {Secondary Fuel} for carbon management by {Carbon Management Technology}
     unit: EJ/yr
-    notes: See `Secondary Energy|{Secondary Fuel}|...` for the sources of the energy carrier
-    navigate: Final Energy|Carbon Removal|{Secondary Fuel}|{Carbon Management Technology}
-    engage: Final Energy|Carbon Removal|{Secondary Fuel}|{Carbon Management Technology}
+    tier: "{Secondary Fuel with Source}"
+    navigate: Final Energy|Carbon Removal|{Secondary Fuel with Source}|{Carbon Management Technology}
+    engage: Final Energy|Carbon Removal|{Secondary Fuel with Source}|{Carbon Management Technology}
 - Final Energy|Carbon Management|{Carbon Management Technology}|Other:
     description: Use of other energy sources for carbon removal by {Carbon Management Technology}
     unit: EJ/yr

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -1,9 +1,17 @@
-- Secondary Fuel:
-    # This should be a sub-set of `tag_secondary_energy_carriers_with_sources.yaml`
+- Secondary Fuel with Source:
+    # This should be a super-set of `tag_secondary_energy_carriers.yaml`
     # Electricity is treated separately from other secondary energy carriers
     - Liquids:
         description: liquid fuels (conventional & unconventional oil, biofuels,
           coal-to-liquids, gas-to-liquids)
+    - Liquids|Biomass:
+        description: liquid fuels from biomass
+    - Liquids|Oil:
+        description: liquid fuels from refined crude oil
+    - Liquids|Coal:
+        description: liquid fuels from coal
+    - Liquids|Gas:
+        description: liquid fuels from fossil methane ("natural gas")
     - Solids:
         description: solid fuels
     - Gases:

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -44,6 +44,21 @@
     - Hydrogen:
         description: hydrogen
         tier: "1"
+    - Hydrogen|Fossil:
+        description: hydrogen from fossils
+        unit: EJ/yr
+        tier: "2"
+    - Hydrogen|Biomass:
+        description: hydrogen generated from biomass
+        unit: EJ/yr
+        tier: "2"
+    - Hydrogen|Electricity:
+        description: hydrogen from electrolysis
+        unit: EJ/yr
+        tier: "2"
+    - Hydrogen|Other:
+        description: hydrogen from other sources
+        tier: "2"
     - Heat:
         description: heat
         tier: "1"

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -20,9 +20,24 @@
     - Solids:
         description: solid fuels
         tier: 1
+    - Solids|Biomass:
+        description: solid biomass
+        tier: 2
+    - Solids|Coal:
+        description: coal and coal products
+        tier: 2
     - Gases:
         description: gaseous fuels not including hydrogen
         tier: 1
+    - Gases|Biomass:
+        description: gas from biogenic sources, mainly biogas
+        tier: 2
+    - Gases|Coal:
+        description: gaseous fuels from coal
+        tier: 2
+    - Gases|Gas:
+        description: fossil methane ("natural gas")
+        tier: 2
     - Hydrogen:
         description: hydrogen
         tier: 1

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -17,6 +17,9 @@
     - Liquids|Gas:
         description: liquid fuels from fossil methane ("natural gas")
         tier: "2"
+    - Liquids|Hydrogen:
+        description: liquid fuels from hydrogen
+        tier: "2"
     - Liquids|Electricity:
         description: liquid synthetic fuels from electricity (e-fuels)
         tier: "2"

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -4,19 +4,28 @@
     - Liquids:
         description: liquid fuels (conventional & unconventional oil, biofuels,
           coal-to-liquids, gas-to-liquids)
+        tier: 1
     - Liquids|Biomass:
         description: liquid fuels from biomass
+        tier: 2
     - Liquids|Oil:
         description: liquid fuels from refined crude oil
+        tier: 2
     - Liquids|Coal:
         description: liquid fuels from coal
+        tier: 2
     - Liquids|Gas:
         description: liquid fuels from fossil methane ("natural gas")
+        tier: 2
     - Solids:
         description: solid fuels
+        tier: 1
     - Gases:
         description: gaseous fuels not including hydrogen
+        tier: 1
     - Hydrogen:
         description: hydrogen
+        tier: 1
     - Heat:
         description: heat
+        tier: 1

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -18,10 +18,36 @@
         description: liquid fuels from fossil methane ("natural gas")
         tier: "2"
     - Liquids|Hydrogen:
-        description: liquid fuels from hydrogen
+        description: liquid fuels from hydrogen (if hydrogen is explicitly modeled as a
+          commodity and not an implicit intermediate product of the transformation technologies)
         tier: "2"
+    - Liquids|Hydrogen|Fossil:
+        description: liquid fuels using hydrogen from fossils (if hydrogen is explicitly
+          modeled as a commodity and not an implicit intermediate product of the
+          transformation technologies)
+        unit: EJ/yr
+        tier: "3"
+    - Liquids|Hydrogen|Biomass:
+        description: liquid fuels using hydrogen generated from biomass (if hydrogen is
+          explicitly modeled as a commodity and not an implicit intermediate product of
+          the transformation technologies)
+        unit: EJ/yr
+        tier: "3"
+    - Liquids|Hydrogen|Electricity:
+        description: liquid fuels using hydrogen from electrolysis, i.e., e-fuels (if
+          hydrogen is explicitly modeled as a commodity and not an implicit intermediate
+          product of the transformation technologies)
+        unit: EJ/yr
+        tier: "3"
+    - Liquids|Hydrogen|Other:
+        description: liquid fuels using hydrogen from other sources (if hydrogen is
+          explicitly modeled as a commodity and not an implicit intermediate product of
+          the transformation technologies)
+        unit: EJ/yr
+        tier: "3"
     - Liquids|Electricity:
-        description: liquid synthetic fuels from electricity (e-fuels)
+        description: liquid synthetic fuels from electricity, i.e., e-fuels (if hydrogen
+          is not explicitly modeled as an intermediate product)
         tier: "2"
     - Solids:
         description: solid fuels

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -17,6 +17,9 @@
     - Liquids|Gas:
         description: liquid fuels from fossil methane ("natural gas")
         tier: "2"
+    - Liquids|Electricity:
+        description: liquid fuels from electricity (e-fuels)
+        tier: "2"
     - Solids:
         description: solid fuels
         tier: "1"

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -18,7 +18,7 @@
         description: liquid fuels from fossil methane ("natural gas")
         tier: "2"
     - Liquids|Electricity:
-        description: liquid fuels from electricity (e-fuels)
+        description: liquid synthetic fuels from electricity (e-fuels)
         tier: "2"
     - Solids:
         description: solid fuels

--- a/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_with_sources.yaml
@@ -4,43 +4,43 @@
     - Liquids:
         description: liquid fuels (conventional & unconventional oil, biofuels,
           coal-to-liquids, gas-to-liquids)
-        tier: 1
+        tier: "1"
     - Liquids|Biomass:
         description: liquid fuels from biomass
-        tier: 2
+        tier: "2"
     - Liquids|Oil:
         description: liquid fuels from refined crude oil
-        tier: 2
+        tier: "2"
     - Liquids|Coal:
         description: liquid fuels from coal
-        tier: 2
+        tier: "2"
     - Liquids|Gas:
         description: liquid fuels from fossil methane ("natural gas")
-        tier: 2
+        tier: "2"
     - Solids:
         description: solid fuels
-        tier: 1
+        tier: "1"
     - Solids|Biomass:
         description: solid biomass
-        tier: 2
+        tier: "2"
     - Solids|Coal:
         description: coal and coal products
-        tier: 2
+        tier: "2"
     - Gases:
         description: gaseous fuels not including hydrogen
-        tier: 1
+        tier: "1"
     - Gases|Biomass:
         description: gas from biogenic sources, mainly biogas
-        tier: 2
+        tier: "2"
     - Gases|Coal:
         description: gaseous fuels from coal
-        tier: 2
+        tier: "2"
     - Gases|Gas:
         description: fossil methane ("natural gas")
-        tier: 2
+        tier: "2"
     - Hydrogen:
         description: hydrogen
-        tier: 1
+        tier: "1"
     - Heat:
         description: heat
-        tier: 1
+        tier: "1"


### PR DESCRIPTION
This PR adds final-energy and emissions variables where the source of a secondary energy carrier is explicitly stated.

For clarification - before this PR, only the following variable existed in the common-definitions variable list
> Final Energy|Liquids

This PR will add
> Final Energy|Liquids|Biomass
> Final Energy|Liquids|Oil
> Final Energy|Liquids|Coal
> Final Energy|Liquids|Gas

also for emissions and sectoral disaggregation variables, and also for Solids and Gases.

This PR responds to requests by @robertpietzcker and @orichters in #39 and @OFR-IIASA (offline).

