### PR TITLE
Add secondary-energy variables for liquids from hydrogen

### DIFF
--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -17,11 +17,20 @@
     description: Production of liquid fuels using hydrogen from fossils (if hydrogen is
       explicitly modeled as a commodity and not an implicit intermediate product of the
       transformation technologies)
+- Secondary Energy|Liquids|Hydrogen|Biomass:
+    description: Production of liquid fuels using hydrogen generated from biomass
+      (if hydrogen is explicitly modeled as a commodity and not an implicit intermediate
+      product of the transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Electricity:
     description: Production of liquid fuels using hydrogen from electrolysis, i.e.,
       "e-fuels" (if hydrogen is explicitly modeled as a commodity and not an implicit
       intermediate product of the transformation technologies)
+    unit: EJ/yr
+- Secondary Energy|Liquids|Hydrogen|Other:
+    description: Production of liquid fuels using hydrogen from other sources
+      (if hydrogen is explicitly modeled as a commodity and not an implicit intermediate
+      product of the transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Liquids|Electricity:
     description: Production of liquid fuels mainly from electricity, i.e., e-fuels

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -17,6 +17,7 @@
     description: Production of liquid fuels using hydrogen from fossils (if hydrogen is
       explicitly modeled as a commodity and not an implicit intermediate product of the
       transformation technologies)
+    unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Biomass:
     description: Production of liquid fuels using hydrogen generated from biomass
       (if hydrogen is explicitly modeled as a commodity and not an implicit intermediate

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -12,14 +12,17 @@
     description: Production of liquid fuels from hydrogen (if hydrogen is explicitly
       modeled as a commodity and not an implicit intermediate product of the
       transformation technologies)
+    unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Fossil:
     description: Production of liquid fuels using hydrogen from fossils (if hydrogen is
       explicitly modeled as a commodity and not an implicit intermediate product of the
       transformation technologies)
+    unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Electricity:
     description: Production of liquid fuels using hydrogen from electrolysis, i.e.,
       "e-fuels" (if hydrogen is explicitly modeled as a commodity and not an implicit
       intermediate product of the transformation technologies)
+    unit: EJ/yr
 - Secondary Energy|Liquids|Electricity:
     description: Production of liquid fuels mainly from electricity, i.e., e-fuels
       (if hydrogen is not explicitly modeled as an intermediate product)

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -8,8 +8,21 @@
 - Secondary Energy|Liquids|{Primary Fossil Fuel}:
     description: Production of fossil liquid fuels from {Primary Fossil Fuel}
     unit: EJ/yr
+- Secondary Energy|Liquids|Hydrogen:
+    description: Production of liquid fuels from hydrogen (if hydrogen is explicitly
+      modeled as a commodity and not an implicit intermediate product of the
+      transformation technologies)
+- Secondary Energy|Liquids|Hydrogen|Fossil:
+    description: Production of liquid fuels using hydrogen from fossils (if hydrogen is
+      explicitly modeled as a commodity and not an implicit intermediate product of the
+      transformation technologies)
+- Secondary Energy|Liquids|Hydrogen|Electricity:
+    description: Production of liquid fuels using hydrogen from electrolysis, i.e.,
+      "e-fuels" (if hydrogen is explicitly modeled as a commodity and not an implicit
+      intermediate product of the transformation technologies)
 - Secondary Energy|Liquids|Electricity:
-    description: Production of liquid fuels from electricity (e-fuels)
+    description: Production of liquid fuels mainly from electricity, i.e., e-fuels
+      (if hydrogen is not explicitly modeled as an intermediate product)
     unit: EJ/yr
 - Secondary Energy|Liquids|Other:
     description: Production of liquids fuels from sources that do not fit any other category

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -25,7 +25,7 @@
     unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Electricity:
     description: Production of liquid fuels using hydrogen from electrolysis, i.e.,
-      "e-fuels" (if hydrogen is explicitly modeled as a commodity and not an implicit
+      e-fuels (if hydrogen is explicitly modeled as a commodity and not an implicit
       intermediate product of the transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Liquids|Hydrogen|Other:
@@ -79,7 +79,9 @@
     unit: EJ/yr
 
 - Secondary Energy|Hydrogen:
-    definition: Total production of hydrogen
+    definition: Total production of hydrogen including hydrogen used as an intermediate
+      product, e.g. for e-fuel production (if hydrogen is explicitly modeled as a
+      commodity and not an implicit intermediate product of the transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Hydrogen|Biomass:
     description: Production of hydrogen from biomass


### PR DESCRIPTION
This PR adds categories for production of liquid fuels from hydrogen where hydrogen is modeled explicitly as a (traded) intermediate commodity. This is a proposed compromise for @fschreyer and @pkyle, see #84 

Given the difference on how e-fuels are represented across models, allowing both and letting the modelers (or the project leads where this template is used) make the choice.

closes #84