### PR TITLE
Variables for agricultural production and consumption

### DIFF
--- a/definitions/variable/agriculture/agriculture.yaml
+++ b/definitions/variable/agriculture/agriculture.yaml
@@ -3,6 +3,84 @@
       and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
     agmip: Domestic use (CONS)
+    tier: 2
+- Agricultural Demand|Crops:
+    definition: Demand for crops including food, feed products and bioenergy
+      (1st & 2nd generation crops)
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Crops|Food:
+    definition: Demand for food crops
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Crops|Feed:
+  definition: Demand for feed crops
+  unit: million t DM/yr
+  agmip: Domestic use (CONS) - ???
+  tier: 3
+- Agricultural Demand|Crops|Bioenergy:
+    definition: Demand for bioenergy crops (1st & 2nd generation)
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Crops|Bioenergy|1st Generation:
+    definition: Demand for 1st generation bioenergy crops
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Crops|Bioenergy|2nd generation:
+    definition: Demand for second-generation bioenergy crops
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Crops|Other:
+    definition: Demand of crops for other uses
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Livestock:
+    definition: Demand for livestock products
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Livestock|Food:
+    definition: Demand for livestock products used as food
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Livestock|Feed:
+    definition: Demand for livestock products used as feed
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Livestock|Other:
+    definition: Demand for livestock products for other uses
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Residues:
+    definition: Demand for residues from agricultural production for feed, bioenergy and
+      other uses
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Residues|Feed:
+    definition: Demand for residues as feed
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Residues|Bioenergy:
+    definition: Demand for residues as bioenergy
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
+- Agricultural Demand|Residues|Other:
+    definition: Demand of residues for other uses
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
 
 - Agricultural Production:
     definition: Total production of food, non-food and feed products (crops and livestock)

--- a/definitions/variable/agriculture/agriculture.yaml
+++ b/definitions/variable/agriculture/agriculture.yaml
@@ -16,10 +16,10 @@
     agmip: Domestic use (CONS) - ???
     tier: 3
 - Agricultural Demand|Crops|Feed:
-  definition: Demand for feed crops
-  unit: million t DM/yr
-  agmip: Domestic use (CONS) - ???
-  tier: 3
+    definition: Demand for feed crops
+    unit: million t DM/yr
+    agmip: Domestic use (CONS) - ???
+    tier: 3
 - Agricultural Demand|Crops|Bioenergy:
     definition: Demand for bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr

--- a/definitions/variable/agriculture/agriculture.yaml
+++ b/definitions/variable/agriculture/agriculture.yaml
@@ -3,8 +3,50 @@
       and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
     agmip: Domestic use (CONS)
+
 - Agricultural Production:
     definition: Total production of food, non-food and feed products (crops and livestock)
       and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
     agmip: Production (PROD)
+    tier: 2
+- Agricultural Production|Crops:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - All crops (CRP)
+    tier: 2
+- Agricultural Production|Crops|Cereals:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - ???
+    tier: 3
+- Agricultural Production|Crops|Sugarcrops:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - Sugarcrops (SGC)
+    tier: 3
+- Agricultural Production|Crops|Oilcrops:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - ???
+    tier: 3
+- Agricultural Production|Crops|Energy Crops:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - Energy crops (ECP)
+    tier: 2
+- Agricultural Production|Crops|Other:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - ???
+    tier: 2
+- Agricultural Production|Livestock:
+    definition: Production of crops
+    unit: million t DM/yr
+    agmip: Production (PROD) - Livestock (LSP)
+    tier: 2
+- Agricultural Production|Residues:
+    definition: Production of agricultural residues
+    unit: million t DM/yr
+    agmip: Production (PROD)
+    tier: 2

--- a/definitions/variable/agriculture/agriculture.yaml
+++ b/definitions/variable/agriculture/agriculture.yaml
@@ -2,9 +2,9 @@
     definition: Total demand for food, non-food and feed products (crops and livestock)
       and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
-    agmip: CONS (Domestic use)
+    agmip: Domestic use (CONS)
 - Agricultural Production:
     definition: Total production of food, non-food and feed products (crops and livestock)
       and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
-    agmip: PROD (Production)
+    agmip: Production (PROD)

--- a/definitions/variable/agriculture/agriculture.yaml
+++ b/definitions/variable/agriculture/agriculture.yaml
@@ -1,0 +1,10 @@
+- Agricultural Demand:
+    definition: Total demand for food, non-food and feed products (crops and livestock)
+      and bioenergy crops (1st & 2nd generation)
+    unit: million t DM/yr
+    agmip: CONS (Domestic use)
+- Agricultural Production:
+    definition: Total production of food, non-food and feed products (crops and livestock)
+      and bioenergy crops (1st & 2nd generation)
+    unit: million t DM/yr
+    agmip: PROD (Production)


### PR DESCRIPTION
This PR is for discussion of adding variables for agricultural production and consumption.

I'm wondering whether to copy over the duplications from the ENGAGE variable template, in particular:

```
Agricultural Demand|Crops
Agricultural Demand|Crops|...
Agricultural Demand|Energy
Agricultural Demand|Energy|Crops
Agricultural Demand|Energy|Crops|1st generation
Agricultural Demand|Energy|Crops|2nd generation
Agricultural Demand|Energy|Residues
Agricultural Demand|Livestock
Agricultural Demand|Livestock|...
Agricultural Demand|Non-Energy
Agricultural Demand|Non-Energy|Crops
Agricultural Demand|Non-Energy|Crops|...
Agricultural Demand|Non-Energy|Livestock
Agricultural Demand|Non-Energy|Livestock|...
```
where `...` indicates distinction by Feed, Food and Other...

Comparing this to the AGMIP variable template, the primary distinction into energy vs. non-energy seems to run counter to the agricultural-modeling logic - a structure "Crops -> Energy vs. Other Uses" would seem more in line with the AGMIP template.

Any thoughts @IAMconsortium/common-definitions-land @IAMconsortium/common-definitions-coordination?
