### PR TITLE
Add variables for land cover

### DIFF
--- a/definitions/region/native_regions/REMIND_3.1.yml
+++ b/definitions/region/native_regions/REMIND_3.1.yml
@@ -26,11 +26,11 @@
     - REMIND 3.1|Latin America and the Caribbean:
         countries: [
           Anguilla, Antarctica, Antigua and Barbuda, Argentina, Aruba, Bahamas,
-          Barbados, Belize, Bermuda, Bolivia, Bonaire, Sint Eustatius and Saba, Bonaire,
-          Sint Eustatius and Saba, Bouvet Island, Brazil, British Virgin Islands,
-          Cayman Islands, Chile, Colombia, Costa Rica, Cuba, Curaçao, Curaçao, Dominica,
-          Dominican Republic, Ecuador, El Salvador, Falkland Islands (Malvinas),
-          French Guiana, Grenada, Guadeloupe, Guatemala, Guyana, Haiti, Honduras,
+          Barbados, Belize, Bermuda, Bolivia, "Bonaire, Sint Eustatius and Saba",
+          Bouvet Island, Brazil, British Virgin Islands, Cayman Islands, Chile,
+          Colombia, Costa Rica, Cuba, Curaçao, Curaçao, Dominica, Dominican Republic,
+          Ecuador, El Salvador, Falkland Islands (Malvinas), French Guiana, Grenada,
+          Guadeloupe, Guatemala, Guyana, Haiti, Honduras,
           Jamaica, Martinique, Mexico, Montserrat, Nicaragua, Panama, Paraguay, Peru,
           Puerto Rico, Saint Barthélemy, Saint Kitts and Nevis, Saint Lucia,
           Saint Martin (French part), Saint Vincent and the Grenadines,
@@ -57,7 +57,7 @@
           Eritrea, Eswatini, Ethiopia, Gabon, Gambia, Ghana, Guinea,
           Guinea-Bissau, Kenya, Lesotho, Liberia, Madagascar, Malawi, Mali,
           Mauritania, Mauritius, Mayotte, Mozambique, Namibia, Niger, Nigeria,
-          Rwanda, Réunion, Saint Helena, Ascension and Tristan da Cunha,
+          Rwanda, Réunion, "Saint Helena, Ascension and Tristan da Cunha",
           Sao Tome and Principe, Senegal, Seychelles, Sierra Leone, Somalia,
           South Africa, South Sudan, Tanzania, Togo, Uganda, Zambia, Zimbabwe
         ]

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -2,6 +2,7 @@
     definition: Total land cover
     unit: million ha
     tier: 2
+    agmip: Land Cover (LAND) - Total (TOT)
 - Land Cover|Built-Up Area:
     definition: Built-up land associated with human settlements
     unit: million ha
@@ -18,10 +19,12 @@
       permanent crops as well as other arable land (physical area)
     unit: million ha
     tier: 2
+    agmip: Land Cover (LAND) - All crops (CRP)
 - Land Cover|Forest:
     definition: Managed and unmanaged forest area
     unit: million ha
     tier: 2
+    agmip: Land Cover (LAND) - Forest (FOR)
 
 - Land Cover|Water Ecosystems:
     definition: Land-use coverage of water-related ecosystems

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -22,6 +22,32 @@
     definition: Managed and unmanaged forest area
     unit: million ha
     tier: 2
+
+- Land Cover|Water Ecosystems:
+    definition: Land-use coverage of water-related ecosystems
+    unit: million ha
+    tier: 3
+- Land Cover|Water Ecosystems|Forests:
+    definition: Land-use coverage of forests in water-related ecosystem
+    unit: million ha
+    tier: 4
+- Land Cover|Water Ecosystems|Glaciers:
+    definition: Area covered by glaciers
+    unit: million ha
+    tier: 4
+- Land Cover|Water Ecosystems|Lakes:
+    definition: Area covered by lakes
+    unit: million ha
+    tier: 4
+- Land Cover|Water Ecosystems|Mountains:
+    definition: 'Land-use coverage of water-related ecosystem: mountains'
+    unit: million ha
+    tier: 4
+- Land Cover|Water Ecosystems|Wetlands:
+    definition: Area covered by wetlands
+    unit: million ha
+    tier: 4
+
 - Land Cover|Other Land:
     definition: other land cover that does not fit into any other category (please
       provide a definition of the sources in this category in the 'comments' tab)

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -26,27 +26,27 @@
 - Land Cover|Water Ecosystems:
     definition: Land-use coverage of water-related ecosystems
     unit: million ha
-    tier: 3
+    tier: 2
 - Land Cover|Water Ecosystems|Forests:
-    definition: Land-use coverage of forests in water-related ecosystem
+    definition: Land-use coverage of forests in water-related ecosystems
     unit: million ha
-    tier: 4
+    tier: 3
 - Land Cover|Water Ecosystems|Glaciers:
     definition: Area covered by glaciers
     unit: million ha
-    tier: 4
+    tier: 3
 - Land Cover|Water Ecosystems|Lakes:
     definition: Area covered by lakes
     unit: million ha
-    tier: 4
+    tier: 3
 - Land Cover|Water Ecosystems|Mountains:
-    definition: Land-use coverage of water-related ecosystem in mountain regions
+    definition: Land-use coverage of water-related ecosystems in mountain regions
     unit: million ha
-    tier: 4
+    tier: 3
 - Land Cover|Water Ecosystems|Wetlands:
     definition: Area covered by wetlands
     unit: million ha
-    tier: 4
+    tier: 3
 
 - Land Cover|Other Land:
     definition: Other land cover that does not fit into any other category

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -20,12 +20,66 @@
     unit: million ha
     tier: 2
     agmip: Land Cover (LAND) - All crops (CRP)
+- Land Cover|Cropland|Cereals:
+    definition: Cropland with maize, rice, temperate cereals and tropical cereals (physical area)
+    unit: million ha
+    tier: 3
+    agmip: 
+- Land Cover|Cropland|Oil Crops:
+    definition: Cropland with cotton seed, groundnuts, oilpalms, other oil crops incl rapeseed, soybean, sunflower (physical area)
+    unit: million ha
+    tier: 3
+    agmip: 
+- Land Cover|Cropland|Sugar Crops:
+    definition: Cropland with sugar beet, sugar cane (physical area)
+    unit: million ha
+    tier: 3
+    agmip: 
+- Land Cover|Cropland|Other Crops:
+    definition: Cropland with fruits, vegetables, nuts, potatoes, pulses, tropical roots (physical area)
+    unit: million ha
+    tier: 3
+    agmip: 
+- Land Cover|Cropland|Energy Crops:
+    definition: Cropland with short rotation grasses, short rotation trees (physical area)
+    unit: million ha
+    tier: 3
+    agmip: 
 - Land Cover|Forest:
     definition: Managed and unmanaged forest area
     unit: million ha
     tier: 2
     agmip: Land Cover (LAND) - Forest (FOR)
-
+- Land Cover|Forest|Managed:
+    definition: Managed forest area incl. timber plantations and re-/afforestation areas
+    unit: million ha
+    tier: 2
+    agmip: 
+- Land Cover|Forest|Managed|Timber Plantations:
+    definition: Managed and unmanaged forest area
+    unit: million ha
+    tier: 2
+    agmip: Land Cover (LAND) - Forest (FOR)
+- Land Cover|Forest|Managed|Afforestation
+    definition: Afforestation area
+    unit: million ha
+    tier: 2
+    agmip: 
+- Land Cover|Forest|Managed|Reforestation
+    definition: Reforestation area
+    unit: million ha
+    tier: 2
+    agmip: 
+- Land Cover|Forest|Secondary Forest:
+    definition: Secondary forest area
+    unit: million ha
+    tier: 2
+    agmip: 
+- Land Cover|Forest|Primary Forest:
+    definition: Primary forest area
+    unit: million ha
+    tier: 2
+    agmip: 
 - Land Cover|Water Ecosystems:
     definition: Land-use coverage of water-related ecosystems
     unit: million ha

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -3,17 +3,20 @@
     unit: million ha
     tier: 2
     agmip: Land Cover (LAND) - Total (TOT)
+
 - Land Cover|Built-Up Area:
     definition: Built-up land associated with human settlements
     unit: million ha
     tier: 2
     engage: Land Cover|Built-up Area
     navigate: Land Cover|Built-up Area
+
 - Land Cover|Pasture:
     definition: Pasture, not only high quality rangeland, based on FAO definition of
       "permanent meadows and pastures"
     unit: million ha
     tier: 2
+
 - Land Cover|Cropland:
     definition: Arable land, i.e. land in bioenergy crop, food, and feed/fodder crops,
       permanent crops as well as other arable land (physical area)
@@ -24,27 +27,28 @@
     definition: Cropland with maize, rice, temperate cereals and tropical cereals (physical area)
     unit: million ha
     tier: 3
-    agmip: 
+    agmip:
 - Land Cover|Cropland|Oil Crops:
     definition: Cropland with cotton seed, groundnuts, oilpalms, other oil crops incl rapeseed, soybean, sunflower (physical area)
     unit: million ha
     tier: 3
-    agmip: 
+    agmip:
 - Land Cover|Cropland|Sugar Crops:
     definition: Cropland with sugar beet, sugar cane (physical area)
     unit: million ha
     tier: 3
-    agmip: 
+    agmip:
 - Land Cover|Cropland|Other Crops:
     definition: Cropland with fruits, vegetables, nuts, potatoes, pulses, tropical roots (physical area)
     unit: million ha
     tier: 3
-    agmip: 
+    agmip:
 - Land Cover|Cropland|Energy Crops:
     definition: Cropland with short rotation grasses, short rotation trees (physical area)
     unit: million ha
     tier: 3
-    agmip: 
+    agmip:
+
 - Land Cover|Forest:
     definition: Managed and unmanaged forest area
     unit: million ha
@@ -54,32 +58,32 @@
     definition: Managed forest area incl. timber plantations and re-/afforestation areas
     unit: million ha
     tier: 2
-    agmip: 
+    agmip:
 - Land Cover|Forest|Managed|Timber Plantations:
-    definition: Managed and unmanaged forest area
+    definition: Area of timber plantations
     unit: million ha
     tier: 2
     agmip: Land Cover (LAND) - Forest (FOR)
-- Land Cover|Forest|Managed|Afforestation
+- Land Cover|Forest|Managed|Afforestation:
     definition: Afforestation area
     unit: million ha
     tier: 2
-    agmip: 
-- Land Cover|Forest|Managed|Reforestation
+    agmip:
+- Land Cover|Forest|Managed|Reforestation:
     definition: Reforestation area
     unit: million ha
     tier: 2
-    agmip: 
+    agmip:
 - Land Cover|Forest|Secondary Forest:
     definition: Secondary forest area
     unit: million ha
     tier: 2
-    agmip: 
+    agmip:
 - Land Cover|Forest|Primary Forest:
     definition: Primary forest area
     unit: million ha
     tier: 2
-    agmip: 
+    agmip:
 - Land Cover|Water Ecosystems:
     definition: Land-use coverage of water-related ecosystems
     unit: million ha

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -40,7 +40,7 @@
     unit: million ha
     tier: 4
 - Land Cover|Water Ecosystems|Mountains:
-    definition: 'Land-use coverage of water-related ecosystem: mountains'
+    definition: Land-use coverage of water-related ecosystem in mountain regions
     unit: million ha
     tier: 4
 - Land Cover|Water Ecosystems|Wetlands:
@@ -49,7 +49,6 @@
     tier: 4
 
 - Land Cover|Other Land:
-    definition: other land cover that does not fit into any other category (please
-      provide a definition of the sources in this category in the 'comments' tab)
+    definition: Other land cover that does not fit into any other category
     unit: million ha
     tier: 2

--- a/definitions/variable/land/land-cover.yaml
+++ b/definitions/variable/land/land-cover.yaml
@@ -84,30 +84,6 @@
     unit: million ha
     tier: 2
     agmip:
-- Land Cover|Water Ecosystems:
-    definition: Land-use coverage of water-related ecosystems
-    unit: million ha
-    tier: 2
-- Land Cover|Water Ecosystems|Forests:
-    definition: Land-use coverage of forests in water-related ecosystems
-    unit: million ha
-    tier: 3
-- Land Cover|Water Ecosystems|Glaciers:
-    definition: Area covered by glaciers
-    unit: million ha
-    tier: 3
-- Land Cover|Water Ecosystems|Lakes:
-    definition: Area covered by lakes
-    unit: million ha
-    tier: 3
-- Land Cover|Water Ecosystems|Mountains:
-    definition: Land-use coverage of water-related ecosystems in mountain regions
-    unit: million ha
-    tier: 3
-- Land Cover|Water Ecosystems|Wetlands:
-    definition: Area covered by wetlands
-    unit: million ha
-    tier: 3
 
 - Land Cover|Other Land:
     definition: Other land cover that does not fit into any other category

--- a/definitions/variable/land/land_cover.yaml
+++ b/definitions/variable/land/land_cover.yaml
@@ -1,0 +1,29 @@
+- Land Cover:
+    definition: Total land cover
+    unit: million ha
+    tier: 2
+- Land Cover|Built-Up Area:
+    definition: Built-up land associated with human settlements
+    unit: million ha
+    tier: 2
+    engage: Land Cover|Built-up Area
+    navigate: Land Cover|Built-up Area
+- Land Cover|Pasture:
+    definition: Pasture, not only high quality rangeland, based on FAO definition of
+      "permanent meadows and pastures"
+    unit: million ha
+    tier: 2
+- Land Cover|Cropland:
+    definition: Arable land, i.e. land in bioenergy crop, food, and feed/fodder crops,
+      permanent crops as well as other arable land (physical area)
+    unit: million ha
+    tier: 2
+- Land Cover|Forest:
+    definition: Managed and unmanaged forest area
+    unit: million ha
+    tier: 2
+- Land Cover|Other Land:
+    definition: other land cover that does not fit into any other category (please
+      provide a definition of the sources in this category in the 'comments' tab)
+    unit: million ha
+    tier: 2

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -340,21 +340,14 @@
     sdg: 14
     unit:
     skip-region-aggregation: true
-- Land Cover:
-    definition: total land cover
-    unit: million ha
-- Land Cover|Cropland:
-    definition: total arable land, i.e. land in bioenergy crop, food, and feed/fodder
-      crops, permant crops as well as other arable land (physical area)
-    unit: million ha
 - Land Cover|Forest|Natural Forest|Primary Forest:
     description: Undisturbed primary natural forests
     sdg: 15
-    unit: million ha   
+    unit: million ha
 - Land Cover|Forest|Natural Forest|Secondary Forest:
     description: Modified natural forests and secondary forests from natural succession
     sdg: 15
-    unit: million ha      
+    unit: million ha
 - Terrestrial Biodiversity|Mean Species Abundance:
     description: Terrestrial biodiversity measured in Mean Species Abundance (MSA)
     sdg: 15


### PR DESCRIPTION
This PR adds variables for land cover based on the xlsx overview developed by @flohump @realxinzhao and @kanishkan91.

This PR does NOT include subcategories for cropland and forests - this will be implemented in a follow-up PR once this discussion is finished and the iniatl set of land-cover variables are merged.

A few observations:
- I added the variable "Land Cover|Water Ecosystems", which has been missing from the templates in NAVIGATE and ENGAGE
- I assigned all water-ecosystems variables as tier 3
- Is there a particular reason why glaciers are a sub-category of water ecosystems?
- The variable for built-up area land cover was renamed for consistency with the naming convention, see [here](https://docs.ece.iiasa.ac.at/iamc/variable.html#variable-naming-conventions)

Please review the descriptions.

@IAMconsortium/common-definitions-land