### PR TITLE
Add variables for food demand

### DIFF
--- a/definitions/variable/agriculture/food.yaml
+++ b/definitions/variable/agriculture/food.yaml
@@ -2,13 +2,19 @@
     definition: Total food demand in calories
     unit: kcal/cap/day
     weight: Population
+    sdg: 2
+    shape: Food|Intake
 - Food Demand|Crops:
     definition: Food demand in calories satisfied by crops
     unit: kcal/cap/day
     weight: Population
+    sdg: 2
     agmip: p.c. calory intake (CALI) - All crops (CRP)
+    shape: Food|Intake|Crops
 - Food Demand|Livestock:
     definition: Food demand in calories satisfied by livestock
     unit: kcal/cap/day
     weight: Population
+    sdg: 2
     agmip: p.c. calory intake (CALI) - Livestock (LSP)
+    shape: Food|Intake|Livestock

--- a/definitions/variable/agriculture/food.yaml
+++ b/definitions/variable/agriculture/food.yaml
@@ -1,0 +1,14 @@
+- Food Demand:
+    definition: Total food demand in calories
+    unit: kcal/cap/day
+    weight: Population
+- Food Demand|Crops:
+    definition: Food demand in calories satisfied by crops
+    unit: kcal/cap/day
+    weight: Population
+    agmip: p.c. calory intake (CALI) - All crops (CRP)
+- Food Demand|Livestock:
+    definition: Food demand in calories satisfied by livestock
+    unit: kcal/cap/day
+    weight: Population
+    agmip: p.c. calory intake (CALI) - Livestock (LSP)

--- a/definitions/variable/agriculture/food.yaml
+++ b/definitions/variable/agriculture/food.yaml
@@ -1,18 +1,18 @@
-- Food Demand:
-    definition: Total food demand in calories
+- Food Demand [per capita]:
+    definition: Total food demand per capita in calories
     unit: kcal/cap/day
     weight: Population
     sdg: 2
     shape: Food|Intake
-- Food Demand|Crops:
-    definition: Food demand in calories satisfied by crops
+- Food Demand|Crops [per capita]:
+    definition: Food demand per capita in calories satisfied by crops
     unit: kcal/cap/day
     weight: Population
     sdg: 2
     agmip: p.c. calory intake (CALI) - All crops (CRP)
     shape: Food|Intake|Crops
-- Food Demand|Livestock:
-    definition: Food demand in calories satisfied by livestock
+- Food Demand|Livestock [per capita]:
+    definition: Food demand per capita in calories satisfied by livestock
     unit: kcal/cap/day
     weight: Population
     sdg: 2

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -88,16 +88,6 @@
     sdg: 2
     unit: kcal/cap/day
     weight: Population
-- Food|Intake [per capita]:
-    description: Food calorie intake per capita
-    sdg: 2
-    unit: kcal/cap/day
-    weight: Population
-- Food|Intake|{Food Options} [per capita]:
-    description: Calorie intake of {Food Options} per capita
-    sdg: 2
-    unit: kcal/cap/day
-    weight: Population
 - Price|Agriculture|Livestock [Index]:
     description: Weighted average price index of livestock
     sdg: 2


### PR DESCRIPTION
This PR adds the variables for food demand based on the xlsx overview developed by @flohump @realxinzhao and @kanishkan91.

I added references to the agmip variables.

For consistency, I suggest that we also rename this variable by adding "[per capita]" at the end, to highlight that these are per-capita variables.

It's not clear to me whether we need to also add "Food Energy Supply" (which existed in ENGAGE and NAVIGATE), but which seem to be overlapping with sub-categories of Agricultural Production, right?