### PR TITLE
Refactor the goods-trade variable

### DIFF
--- a/definitions/variable/macro-economy/trade.yaml
+++ b/definitions/variable/macro-economy/trade.yaml
@@ -1,10 +1,6 @@
-- Trade|Export [Value]:
-    description: total exports measured in monetary quantities
+- Trade|Goods [Value]:
+    description: Net exports of all goods measured in monetary quantities
     unit: billion USD_2010/yr
     tier: 1
-    min: 0
-- Trade|Import [Value]:
-    description: total imports measured in monetary quantities
-    unit: billion USD_2010/yr
-    tier: 1
-    min: 0
+    navigate: Trade
+    engage: Trade


### PR DESCRIPTION
Based on an email by @gunnar-pik, I realized that the goods-trade variable introduced in #57 deviated from the NAVIGATE and ENGAGE templates by separating imports and exports. I'm not sure if that distinction is strictly necessary?

Also, I suggest to add the Goods category to clarify that this should not include the energy or emissions-allowance trade (see #147).