### PR TITLE
Add an "International" region

### DIFF
--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -1,5 +1,8 @@
 - common:
     - World
+    - International:
+        description: This region should be used if data cannot be assigned to a
+          specific region, e.g., emissions from bunker fuels in aviation or shipping
 
 # The R5 definitions are taken from the call for submissions
 # to the AR6 WG3 scenario ensemble


### PR DESCRIPTION
Per comments by @jkikstra and @byersiiasa, this PR adds an "International" region that can be used for data that cannot be assigned to a specific region, e.g., emissions related to bunker fuels in international aviation and shipping.

Using this region would allow that aggregation of "World = sum of regions + International" works as expected.

closes #74 