### PR TITLE
Fix legacy-mapping for production variables

### DIFF
--- a/definitions/variable/industry/tag_chemical_commodities.yaml
+++ b/definitions/variable/industry/tag_chemical_commodities.yaml
@@ -10,6 +10,8 @@
         description: high-value chemicals, a group of primary chemicals consisting of
           ethylene, propylene, butylenes and aromatics
         tier: "1"
+        navigate: High Value Chemicals
+        engage: High Value Chemicals
     - High-Value Chemicals|Ethylene:
         description: ethylene, most important precursor for synthetic plastics
         tier: "2"
@@ -25,13 +27,13 @@
     - Plastics|Primary:
         description: plastics, produced from virgin feedstocks
         tier: "2"
-        navigate: Primary Plastics
-        engage: Primary Plastics
+        navigate: Plastics|Primary Plastics
+        engage: Plastics|Primary Plastics
     - Plastics|Secondary:
         description: plastics, produced in recycling processes
         tier: "2"
-        navigate: Secondary Plastics
-        engage: Secondary Plastics
+        navigate: Plastics|Secondary Plastics
+        engage: Plastics|Secondary Plastics
     - Methanol:
         description: methanol, used as precursor for various chemicals and fuels
         tier: "1"

--- a/definitions/variable/industry/tag_non-ferrous_commodities.yaml
+++ b/definitions/variable/industry/tag_non-ferrous_commodities.yaml
@@ -2,13 +2,19 @@
     - Aluminum:
         description: aluminum
         tier: "2"
+        engage: Aluminium
+        navigate: Aluminium
     - Aluminum|Primary:
         description: aluminum produced by electrolysis of alumina
         tier: "3"
+        engage: Aluminium|Primary
+        navigate: Aluminium|Primary
     - Aluminum|Secondary:
         description: aluminum produced by re-melting of scrap or that originates from a
           recycling process, including processing of waste streams from primary production
         tier: "3"
+        engage: Aluminium|Secondary
+        navigate: Aluminium|Secondary
     - Aluminum Oxide:
         description: aluminum oxide (alumina), commonly produced via the Bayer process
           from bauxite


### PR DESCRIPTION
When implementing the corresponding updates to https://github.com/IAMconsortium/legacy-definitions following the merge of the production variables PR by @macflo8, I noticed that the mapping to the legacy-variables was not quite correct.