### PR TITLE
Add capacity variables for non-electricity secondary energy

### DIFF
--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -2,3 +2,12 @@
     description: Production of {Secondary Fuel Level 3}
     unit: EJ/yr
     tier: "{Secondary Fuel Level 3}"
+
+- Capacity|{Secondary Fuel Level 2}:
+    description: Installed (available) capacity to produce {Secondary Fuel Level 2}
+    unit: GW
+    tier: "{Secondary Fuel Level 2}"
+- Capacity|{Secondary Fuel Level 2}|{CCS}:
+    description: Installed (available) capacity to produce {Secondary Fuel Level 2} {CCS}
+    unit: GW
+    tier: "{Secondary Fuel Level 2}"

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -1,4 +1,4 @@
 - Secondary Energy|{Secondary Fuel Level 3}:
-    description: Total production of {Secondary Fuel Level 3}
+    description: Production of {Secondary Fuel Level 3}
     unit: EJ/yr
     tier: "{Secondary Fuel Level 3}"


### PR DESCRIPTION
This PR adds variables for non-electricity secondary energy, including a distinction into with-CCS-vs.-without CCS, based on a spreadsheet sent by @gunnar-pik.

This implementation adds a few combinations that may not make sense - they will be filtered out in a follow-up PR (but this requires some work on the nomenclature package (see https://github.com/IAMconsortium/nomenclature/issues/416).

FYI @IAMconsortium/common-definitions-energy @IAMconsortium/common-definitions-coordination 