### PR TITLE
Change description of "China+ (R10)" region

### DIFF
--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -190,7 +190,7 @@
         notes: Depending on the spatial resolution, some models report Northern Africa
           as part of the Middle East region.
     - China+ (R10):
-        description: Centrally-planned Asia, primarily China
+        description: Eastern Asia, primarily China
         ar6: R10CHINA+
         countries: [ China, Hong Kong, Macao, Mongolia, North Korea, South Korea ]
     - Europe (R10):


### PR DESCRIPTION
Per a comment by @korsbakken, this PR changes the description of the "China+ (R10)" region to avoid the phrase "centrally planned", which doesn't apply to South Korea (which is part of that region for legacy reasons).

The new description as "Eastern Asia" follows the IPCC AR WG3 Annex 2, page 1823, see https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Annex-II.pdf

Closes #160