### PR TITLE
Add capacity (addition) variables for electricity generation

### DIFF
--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -12,13 +12,13 @@
     description: Installed (available) capacity to generate electricity from {Electricity Source}
     unit: GW
 - Capacity Addition|Electricity:
-    description: Total annual additions to installed (available) electricity generation capacity
+    description: Total annual new installation of electricity generation capacity
     unit: GW
-    notes: This variable should be computed as yearly average additions between previous
-      and current reported time step.
+    notes: This variable should be computed as yearly average additions between the previous
+      and the current reported time step.
 - Capacity Addition|Electricity|{Electricity Source}:
-    description: Annual addition to installed (available) capacity to generate
-      electricity from {Electricity Source}
+    description: Annual new installation of capacity to generate electricity
+      from {Electricity Source}
     unit: GW
-    notes: This variable should be computed as yearly average additions between previous
-      and current reported time step.
+    notes: This variable should be computed as yearly average additions between the previous
+      and the current reported time step.

--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -1,6 +1,24 @@
 - Secondary Energy|Electricity:
     description: Total net electricity generation
     unit: EJ/yr
-- Secondary Energy|Electricity|{Electricity Sources}:
-    description: Net electricity generation from {Electricity Sources}
+- Secondary Energy|Electricity|{Electricity Source}:
+    description: Net electricity generation from {Electricity Source}
     unit: EJ/yr
+
+- Capacity|Electricity:
+    description: Total installed (available) electricity generation capacity
+    unit: GW
+- Capacity|Electricity|{Electricity Source}:
+    description: Installed (available) capacity to generate electricity from {Electricity Source}
+    unit: GW
+- Capacity Addition|Electricity:
+    description: Total annual additions to installed (available) electricity generation capacity
+    unit: GW
+    notes: This variable should be computed as yearly average additions between previous
+      and current reported time step.
+- Capacity Addition|Electricity|{Electricity Source}:
+    description: Annual addition to installed (available) capacity to generate
+      electricity from {Electricity Source}
+    unit: GW
+    notes: This variable should be computed as yearly average additions between previous
+      and current reported time step.

--- a/definitions/variable/energy/tag_secondary_electricity_sources.yaml
+++ b/definitions/variable/energy/tag_secondary_electricity_sources.yaml
@@ -1,4 +1,4 @@
-- Electricity Sources:
+- Electricity Source:
     - Biomass:
         description: purpose-grown bioenergy crops, biogas, crop and forestry residue,
           municipal solid waste bioenergy and traditional biomass


### PR DESCRIPTION
This PR adds investment variables suggested by @gunnar-pik for capacity and capacity additions of electricity generation.

One clarifying question: when I read this description, the capacity-addition variable should be reported as net-change (not just new investment). So if 1 GW of wind turbines are built and 0.2 GW of wind turbines are decommissioned in the same year (due to age), the variable should be reported as 0.8 GW.

Is my understanding correct, and should this be made more explicit in the description or notes?