### PR TITLE
Update LU emissions

### DIFF
--- a/definitions/variable/emissions/carbon-removal.yaml
+++ b/definitions/variable/emissions/carbon-removal.yaml
@@ -3,7 +3,12 @@
       or biomass through deliberate human activities
     unit: Mt CO2/yr
     notes: Values should be reported as positive numbers
+    tier: 1
+    domain: CDR
 - Carbon Removal|{Carbon-Removal Option}:
     description: Gross removals of carbon dioxide (CO2) by {Carbon-Removal Option}
     unit: Mt CO2/yr
     notes: Values should be reported as positive numbers
+    tier: "{Carbon-Removal Option}"
+    domain: CDR
+    subdomain: "{Carbon-Removal Option}"

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -22,45 +22,109 @@
     description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC category 3)
     unit: "{Level-2 Species}"
+# Some should be Tier-1, e.g. "Emissions|CH4|AFOLU". How to do this?
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock:
     description: Emissions of {Level-3 Species} from livestock in the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Enteric Fermentation:
     description: Emissions of {Level-3 Species} from enteric fermentation of livestock
       in the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Manure Management:
     description: Emissions of {Level-3 Species} from processes involving
       manure (waste) management in Livestock in the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Rice:
     description: Emissions of {Level-3 Species} from rice cultivation
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Managed Soils:
     description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
     description: Emissions of {Level-3 Species} from managed peatlands (drained and rewetted)
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Land|Forest Burning:
     description: Emissions and removals of {Level-3 Species} from land with woody vegetation
       (forests, IPCC category 3B1)
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Land|Grassland Burning:
     description: Emissions and removals of {Level-3 Species} from rangelands and pasture land
       (IPCC category 3B3)
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
 - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Burning:
     description: Emissions and removals of {Level-3 Species} from any other categories
       of land burning (e.g. peatlands)
     unit: "{Level-3 Species}"
+    tier: 2
+    domain: Emissions
+    subdomain: AFOLU
+
+- Gross Emissions|CO2|Land:
+    description: Gross emissions of carbon dioxide (CO2) from deforestation, 
+      other land-use change (LUC) and forest management
+    unit: Mt CO2/yr
+    tier: 3
+    domain: Emissions
+    subdomain: AFOLU
+- Gross Emissions|CO2|Land|Deforestation:
+    description: Gross emissions of carbon dioxide (CO2) from deforestation
+    unit: Mt CO2/yr
+    tier: 3
+    domain: Emissions
+    subdomain: AFOLU
+- Gross Emissions|CO2|Land|Other LUC:
+    description: Gross emissions of carbon dioxide (CO2) from other land-use change (LUC)
+    unit: Mt CO2/yr
+    tier: 3
+    domain: Emissions
+    subdomain: AFOLU
+- Gross Emissions|CO2|Land|Forest Management:
+    description: Gross emissions of carbon dioxide (CO2) from Forest Management
+    unit: Mt CO2/yr
+    tier: 3
+    domain: Emissions
+    subdomain: AFOLU
+
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors

--- a/definitions/variable/emissions/tag_carbon-removal.yaml
+++ b/definitions/variable/emissions/tag_carbon-removal.yaml
@@ -1,21 +1,48 @@
 - Carbon-Removal Option:
-    - Forestry:
-        description: all forestry-related carbon dioxide removal methods, in particular
-          afforestation, reforestation, agroforestry and improved forest management
+    - Re-Afforestation:
+        description: Re-Afforestation
+        tier: 2
+        subdomain: Land-based
+    - Agroforestry:
+        description: Agroforestry
+        tier: 2
+        subdomain: Land-based
+    - Forest Management:
+        description: Forest Management
+        tier: 2
+        subdomain: Land-based
     - Peatland and Wetland Restoration:
         description: restoration of peat and coastal wetlands
+        tier: 3
+        subdomain: Land-based
     - Soil Carbon Sequestration:
-        description: soil carbon sequestration in croplands and graslands
+        description: soil carbon sequestration in croplands and grasslands
+        tier: 2
+        subdomain: Land-based
+    - Soil Carbon Sequestration|Cropland:
+        description: soil carbon sequestration in croplands
+        tier: 2
+        subdomain: Land-based
+    - Soil Carbon Sequestration|Grassland:
+        description: soil carbon sequestration in grasslands
+        tier: 2
+        subdomain: Land-based
     - Durable Wood Products:
         description: use of durable wood products and building elements
+        tier: 3
+        subdomain: Land-based
     - Biochar:
         description: conversion of biomass to recalcitrant carbon via pyrolysis and its
           subsequent application to croplands to increase soil carbon stocks
+        tier: 3
+        subdomain: Land-based
     - Bio-Oil Storage:
         description: use of bio-oil
     - Bioenergy with CCS:
         description: use of bioenergy in combination with carbon-capture and
           sequestration (CCS)
+        tier: 2
+        subdomain: Land-based
     - Direct Air Capture with CCS:
         description: direct air capture in combination with carbon-capture and
           sequestration (CCS)
@@ -25,6 +52,8 @@
         description: use of mineral products for carbon sequestration
     - Biomass Burial:
         description: burial of biomass on land
+        tier: 3
+        subdomain: Land-based
     - Ocean Fertilization:
         description: ocean fertilization and artificial upwelling
     - Biomass Sinking:


### PR DESCRIPTION
This revision of reporting variables is part of a larger set of changes related to AFOLU reporting variables that have been discussed and agreed with representative of all modeling teams in @IAMconsortium/common-definitions-land 
The revision is based on https://1drv.ms/x/s!AlN2Seu8OCz8hLQ8Wh_ysgHyDSg4QA
For consistency with naming conventions some variables have been named and defined differently.
The purpose of tier, domain and subdomain is to allow for automated checks of reported variables in specific domains.

@danielhuppmann For the tier-levels of Emissions I need some help. E.g. "Emissions|CH4|AFOLU" should be Tier-1 but "Emissions|Kyoto Gases|AFOLU" should be Tier-2. How to do this in the existing structure?