### PR TITLE
LU water

### DIFF
--- a/definitions/variable/water/water.yaml
+++ b/definitions/variable/water/water.yaml
@@ -11,9 +11,15 @@
 - Water Withdrawal|Irrigation:
     definition: Water withdrawal for irrigation
     unit: km3/yr
+    tier: 2
+    domain: AFOLU
+    subdomain: Water
 - Water Withdrawal|Livestock:
     definition: Water withdrawals for livestock
     unit: km3/yr
+    tier: 3
+    domain: AFOLU
+    subdomain: Water
 
 - Water Consumption:
     definition: Total water consumption
@@ -28,6 +34,12 @@
 - Water Consumption|Irrigation:
     definition: Water consumption for irrigation
     unit: km3/yr
+    tier: 2
+    domain: AFOLU
+    subdomain: Water
 - Water Consumption|Livestock:
     definition: Water consumption for livestock
     unit: km3/yr
+    tier: 3
+    domain: AFOLU
+    subdomain: Water

--- a/definitions/variable/water/water.yaml
+++ b/definitions/variable/water/water.yaml
@@ -12,14 +12,10 @@
     definition: Water withdrawal for irrigation
     unit: km3/yr
     tier: 2
-    domain: AFOLU
-    subdomain: Water
 - Water Withdrawal|Livestock:
     definition: Water withdrawals for livestock
     unit: km3/yr
     tier: 3
-    domain: AFOLU
-    subdomain: Water
 
 - Water Consumption:
     definition: Total water consumption
@@ -35,11 +31,7 @@
     definition: Water consumption for irrigation
     unit: km3/yr
     tier: 2
-    domain: AFOLU
-    subdomain: Water
 - Water Consumption|Livestock:
     definition: Water consumption for livestock
     unit: km3/yr
     tier: 3
-    domain: AFOLU
-    subdomain: Water


### PR DESCRIPTION
This revision of reporting variables is part of a larger set of changes related to AFOLU reporting variables that have been discussed and agreed with representative of all modeling teams in @IAMconsortium/common-definitions-land 
The revision is based on https://1drv.ms/x/s!AlN2Seu8OCz8hLQ8Wh_ysgHyDSg4QA
For consistency with naming conventions some variables have been named and defined differently.
The purpose of tier, domain and subdomain is to allow for automated checks of reported variables in specific domains.