### PR TITLE
Cmip7 Emissions Variables List (v0)

### DIFF
--- a/definitions/region/g20.yaml
+++ b/definitions/region/g20.yaml
@@ -23,5 +23,5 @@
     - African Union
     - European Union
     - European Union and United Kingdom:
-        note: This region is used for models that do not have a distinct regional
+        notes: This region is used for models that do not have a distinct regional
           resolution for the United Kingdom and the European Union.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -43,7 +43,7 @@
       For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|AFOLU|Agriculture
-      - Emissions|{Level-3 Species}|AFOLU|Biomass Burning
+      - Emissions|{Level-3 Species}|AFOLU|Agricultural Waste Burning
       - Emissions|{Level-3 Species}|AFOLU|Land
 - Gross Emissions|CO2|AFOLU:
   description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
@@ -56,28 +56,36 @@
 
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
+      (IPCC 1996 category 4; IPCC 2006 category 3A and 3C except 3C1)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock:
     description: Emissions of {Level-3 Species} from livestock in the agriculture sector
+      (IPCC 1996 category 4A and 4B; IPCC 2006 category 3A)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Enteric Fermentation:
     description: Emissions of {Level-3 Species} from enteric fermentation of livestock
+      (IPCC 1996 category 4A; IPCC 2006 category 3A1)
       in the agriculture sector
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Manure Management:
     description: Emissions of {Level-3 Species} from processes involving
       manure (waste) management in Livestock in the agriculture sector
+      (IPCC 1996 category 4B; IPCC 2006 category 3A2)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Rice:
     description: Emissions of {Level-3 Species} from rice cultivation
+      (IPCC 1996 category 4C; IPCC 2006 category 3C7)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Managed Soils:
     description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
+      (IPCC 1996 category 4D; IPCC 2006 category 3C4 and 3C5)
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Biomass Burning:
+- Emissions|{Level-3 Species}|AFOLU|Agricultural Waste Burning:
     description: Emissions from agricultural waste burning
+      (IPCC 1996 category 4F; partially IPCC 2006 category 3C1)
     unit: "{Level-3 Species}"
+    notes: Also sometimes known as 'biomass burning' or 'open agricultural burning'
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use and 
       land use change. Removals in this variable include agroforestry, re/afforestation, 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -43,12 +43,6 @@
       see "Emissions|*". Emissions reported in this category represent 
       fluxes from the land pool to the atmosphere.
   unit: Mt CO2/yr
-- Gross Emissions|CO2|AFOLU|Deforestation:
-  description: Gross emissions of carbon dioxide (CO2) from deforestation
-- Gross Emissions|CO2|AFOLU|Other Land:
-  description: Gross emissions of carbon dioxide (CO2) from other land-use change
-- Gross Emissions|CO2|AFOLU|Forest Management:
-  description: Gross emissions of carbon dioxide (CO2) from forest management
 
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -42,15 +42,15 @@
     notes: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
       For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
-      - Emissions|{Level-3 Species}|AFOLU|Agriculture
-      - Emissions|{Level-3 Species}|AFOLU|Agricultural Waste Burning
-      - Emissions|{Level-3 Species}|AFOLU|Land
+      - Emissions|{Level-2 Species}|AFOLU|Agriculture
+      - Emissions|{Level-2 Species}|AFOLU|Agricultural Waste Burning
+      - Emissions|{Level-2 Species}|AFOLU|Land
 - Gross Emissions|CO2|AFOLU:
   description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
       This is emissions sources only. All removals (for example, 
       removals from biochar) are not included here. For net emissions, 
-      see "Emissions|*". Emissions reported in this category represent 
+      see "Emissions|CO2|AFOLU". Emissions reported in this category represent 
       fluxes from the land pool to the atmosphere.
   unit: Mt CO2/yr
 
@@ -102,7 +102,7 @@
 - Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change:
     description: Emissions and removals from land use and land-use change,
       including emissions from deforestation and conversion from all other natural land,
-      as well as removals from the atmosphere through agroforestry, re/afforestation
+      as well as removals from the atmosphere through agroforestry or re/afforestation
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change|Wetlands:
     description: Emissions from land that is covered or saturated by water for

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -1,6 +1,9 @@
 # Emissions species are grouped into three levels of detail for the reporting.
 # Level-1 reports aggregate emissions, Level-3 has the most detailed disaggregation.
 # Gross emissions are only defined for CO2.
+# Emissions reporting guidance follows IPCC guidance, referring to 
+# 2006 categories: https://www.ipcc-nggip.iges.or.jp/public/2019rf/pdf/1_Volume1/19R_V1_Ch08_Reporting_Guidance.pdf
+# 1996 categories: https://github.com/primap-community/climate_categories/blob/main/climate_categories/data/IPCC1996.yaml
 
 - Emissions|{Level-1 Species}:
     description: Emissions of {Level-1 Species}, net of emissions to the atmosphere and the removal of {Level-1 Species} from the atmosphere.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -294,8 +294,7 @@
       technologies that are not directly linked 
       to an emissions source, including direct air carbon capture and storage (DACCS) or enhanced 
       weathering (EW), as well as durable wood products in building elements, mineral products, 
-      ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture, 
-      and other methods
+      ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture
     unit: "{Level-3 Species}"
     note: This timeseries should be reported as negative values so that subcategories of
       emissions add up to net emissions `Emissions|{Level-3 Species}`.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -12,7 +12,7 @@
       contributions. For positive contributions only, see 
       "Gross Emissions|*").
     unit: "{Level-1 Species}"
-    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-1 Species}|AFOLU
       - Emissions|{Level-1 Species}|Energy
@@ -39,7 +39,7 @@
       use CCS such as soil carbon sequestration, biochar, forestry, and re/afforestation and 
       agroforestry. 
     unit: "{Level-2 Species}"
-    note: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
+    notes: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
       For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|AFOLU|Agriculture
@@ -82,7 +82,7 @@
     description: Emissions of {Level-3 Species} from forestry and other land use and 
       land use change
     unit: "{Level-3 Species}"
-    note: Emissions from land use change are reported under the land use type
+    notes: Emissions from land use change are reported under the land use type
       that the land is converted to. For instance, deforestation for the creation
       of new cropland is reported under "Emissions|*|AFOLU|Land|Cropland".
     components:
@@ -96,7 +96,7 @@
 - Emissions|{Level-3 Species}|AFOLU|Land|Forest Land:
     description: Emissions and removals from lands with woody vegetation
       (partially IPCC 1996 category 5A/5B/5D; IPCC 2006 category 3B1) 
-    note: It also includes systems with vegetation that currently fall below, 
+    notes: It also includes systems with vegetation that currently fall below, 
       but are expected to later exceed, the threshold values used by a country to
       define the forest land category.
     unit: "{Level-3 Species}"
@@ -105,7 +105,7 @@
       fields, and agro-forestry systems where vegetation falls
       below the thresholds used for the forest land category
       (no clear IPCC 1996 category; IPCC 2006 category 3B2)
-    note: This does not include methane emissions from rice cultivation
+    notes: This does not include methane emissions from rice cultivation
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Grassland:
     description: Emissions and removals from rangelands and pasture land
@@ -113,7 +113,7 @@
       woody vegetation that fall below the threshold values used
       in the forest land category and are not expected to exceed
       them, without human intervention (partially IPCC 1996 category 4D/4E/5A/5B/5C/5D; IPCC 2006 category 3B3).
-    note: The category also includes all grassland from wild lands to recreational 
+    notes: The category also includes all grassland from wild lands to recreational 
       areas as well as agricultural and silvi-pastural systems, subdivided
       into managed and unmanaged, consistent with national
       definitions.
@@ -123,7 +123,7 @@
       all or part of the year (e.g., peatland) and that does not fall
       into the forest land, cropland, grassland or settlements
       categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4) 
-    note: It includes reservoirs as a managed sub-division and 
+    notes: It includes reservoirs as a managed sub-division and 
       natural rivers and lakes as unmanaged sub-divisions
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Settlements:
@@ -157,7 +157,7 @@
       including emissions from international bunker fuels. This is the sum of sources and sinks, and 
       includes negative emisisons in these sectors, for instance from bioenergy with CCS (BECCS)
     unit: "{Level-3 Species}"
-    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|Energy
       - Emissions|{Level-3 Species}|Industrial Processes
@@ -178,7 +178,7 @@
       emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply 
       and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage
     unit: "{Level-2 Species}"
-    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|Energy|Supply
       - Emissions|{Level-3 Species}|Energy|Demand
@@ -314,7 +314,7 @@
       and sinks, including negative emissions such as those from cement carbonation
       processes and other forms of capture and storage on industrial processes
     unit: "{Level-3 Species}"
-    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions 
@@ -368,6 +368,6 @@
       weathering (EW), as well as durable wood products in building elements, mineral products, 
       ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture
     unit: "{Level-3 Species}"
-    note: This timeseries should be reported as negative values so that subcategories of
+    notes: This timeseries should be reported as negative values so that subcategories of
       emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon 
       removals, see the "Carbon Removal|*" tree

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -21,8 +21,10 @@
       - Emissions|{Level-1 Species}|Product Use
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
-    description: Gross emissions of carbon dioxide (CO2), not accounting for 
-      emissions removed from the atmosphere
+    description: Gross emissions of carbon dioxide (CO2). 
+      This is emissions sources only. All removals (for example, 
+      removals from BECCS or direct air carbon capture and storage (DACCS)) 
+      are not included here. For net emissions, see "Emissions|*".
     unit: Mt CO2/yr
 
 - Emissions|{Level-2 Species}|AFOLU:
@@ -34,10 +36,12 @@
       category represent fluxes to/from the atmosphere from/to the land pool.
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|AFOLU:
-  description: Gross emissions of carbon dioxide (CO2), i.e. the sum of all positive emissions 
-      (excluding all negative emissions), from agriculture, forestry
-      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3). Emissions reported in this 
-      category represent fluxes from the land pool to the atmosphere.
+  description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
+      This is emissions sources only. All removals (for example, 
+      removals from biochar) are not included here. For net emissions, 
+      see "Emissions|*". Emissions reported in this category represent 
+      fluxes from the land pool to the atmosphere.
   unit: Mt CO2/yr
 - Gross Emissions|CO2|AFOLU|Deforestation:
   description: Gross emissions of carbon dioxide (CO2) from deforestation

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -96,7 +96,7 @@
     description: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
       including emissions from international bunker fuels, not accounting for 
-      emissions removed from the atmosphere
+      removals from the atmosphere
     unit: Mt CO2/yr
     components:
       - Gross Emissions|CO2|Energy
@@ -196,7 +196,7 @@
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -30,13 +30,16 @@
 
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
-      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3), 
-      reporting the sum of sources and sinks including land-use methods that do not 
-      use CCS such as soil carbon sequestration, biochar, forestry, peatland 
-      and wetland restoration, and biomass burial. Emissions reported in this 
-      category represent fluxes to/from the atmosphere from/to the land pool.
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
+      In particular, this includes agricultural emissions (mostly non-CO2) 
+      from livestock, rice cultivation and soil management as well as 
+      emissions from land use and land-use change (mostly CO2) such as deforestation, 
+      conversion of non-forest natural land, and drained peatlands. 
+      This is reporting the sum of sources and sinks including land-use methods that do not 
+      use CCS such as soil carbon sequestration, biochar, forestry, and re/afforestation and 
+      agroforestry. 
     unit: "{Level-2 Species}"
-    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    note: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|AFOLU|Agriculture
       - Emissions|{Level-3 Species}|AFOLU|Biomass Burning

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -95,60 +95,37 @@
       that the land is converted to. For instance, deforestation for the creation
       of new cropland is reported under "Emissions|*|AFOLU|Land|Cropland".
     components:
-      - Emissions|{Level-3 Species}|AFOLU|Land|Forest Land
-      - Emissions|{Level-3 Species}|AFOLU|Land|Cropland
-      - Emissions|{Level-3 Species}|AFOLU|Land|Grassland
-      - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands
-      - Emissions|{Level-3 Species}|AFOLU|Land|Settlements
-      - Emissions|{Level-3 Species}|AFOLU|Land|Other Land
+      - Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change
       - Emissions|{Level-3 Species}|AFOLU|Land|Fires
-- Emissions|{Level-3 Species}|AFOLU|Land|Forest Land:
-    description: Emissions and removals from lands with woody vegetation
-      (partially IPCC 1996 category 5A/5B/5D; IPCC 2006 category 3B1) 
-    notes: It also includes systems with vegetation that currently fall below, 
-      but are expected to later exceed, the threshold values used by a country to
-      define the forest land category.
+      - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products
+      - Emissions|{Level-3 Species}|AFOLU|Land|Other
+- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change:
+    description: Emissions and removals from land use and land-use change,
+      including emissions from deforestation and conversion from all other natural land,
+      as well as removals from the atmosphere through agroforestry, re/afforestation
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Cropland:
-    description: Emissions and removals from arable and tillage land, rice
-      fields, and agro-forestry systems where vegetation falls
-      below the thresholds used for the forest land category
-      (no clear IPCC 1996 category; IPCC 2006 category 3B2)
-    notes: This does not include methane emissions from rice cultivation
-    unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Grassland:
-    description: Emissions and removals from rangelands and pasture land
-      that is not considered cropland. It also includes systems with
-      woody vegetation that fall below the threshold values used
-      in the forest land category and are not expected to exceed
-      them, without human intervention (partially IPCC 1996 category 4D/4E/5A/5B/5C/5D; IPCC 2006 category 3B3).
-    notes: The category also includes all grassland from wild lands to recreational 
-      areas as well as agricultural and silvi-pastural systems, subdivided
-      into managed and unmanaged, consistent with national
-      definitions.
-    unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
+- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change|Wetlands:
     description: Emissions from land that is covered or saturated by water for
       all or part of the year (e.g., peatland) and that does not fall
       into the forest land, cropland, grassland or settlements
       categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4) 
-    notes: It includes reservoirs as a managed sub-division and 
-      natural rivers and lakes as unmanaged sub-divisions
+    notes: Includes reservoirs as a managed sub-division and 
+      natural rivers and lakes as unmanaged sub-divisions. Includes drained 
+      and rewetted wetlands, does not include natural emissions from intact wetlands.
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Settlements:
-    description: Emissions and removals from all developed land, including
-      transportation infrastructure and human settlements of any
-      size, unless they are already included under other
-      categories (partially IPCC 1996 category 5A/5B/5D/5E; IPCC 2006 category 3B5).
+- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change|Other:
+    description: Emissions and removals from forest land, cropland, grassland,
+      settlements, and other land that cannot be accommodated in other categories
+      (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4). 
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Other Land:
-    description: Emissions and removals from bare soil, rock, ice, and all
-      unmanaged land areas that do not fall into any of the other
-      land categories (no clear IPCC 1996 category; IPCC 2006 category 3B6). 
-    unit: "{Level-3 Species}"
+    notes: Only includes anthropogenic emissions. Does not include wetlands.
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires:
     description: Emissions from land fires and deforestation & degradation
     unit: "{Level-3 Species}"
+    components:
+      - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning
+      - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Forest Burning
+      - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning:
     description: Emissions from peat fires
     unit: "{Level-3 Species}"
@@ -158,6 +135,15 @@
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
     description: Emissions from savanna, grassland, and shrubland fires
+    unit: "{Level-3 Species}"  
+- Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products:
+    description: Emissions and removals from harvested wood products (HWP)
+      (no clear IPCC 1996 category; IPCC 2006 category 3D1)
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Other:
+    description: Emissions and removals from land that cannot be 
+      accommodated in other categories (no clear IPCC 1996 category; 
+      IPCC 2006 category 3D2) 
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -286,7 +286,7 @@
 - Emissions|{Level-2 Species}|Other:
     description: Emissions of {Level-2 Species} from other sources, (IPCC 1996 category 7; IPCC 2006 category 5B; including fossil fuel fires). 
       Only use this category exceptionally, for any categories than cannot be accommodated in the categories described above. 
-      Unless specified otherwise, this will be treated as a flux from some fossil reservoir to the atmosphere in climate models.
+      notes: This will be treated as a flux from some fossil reservoir to the atmosphere in climate models.
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -287,7 +287,7 @@
     description: Emissions of {Level-2 Species} from other sources (IPCC 1996 category 7;
       IPCC 2006 category 5B) including fossil fuel fires and any sources or sinks that
       cannot be accommodated in other categories
-      notes: This will be treated as a flux from some fossil reservoir to the atmosphere in climate models.
+      notes: This will be treated as a flux from the fossil reservoir to the atmosphere in climate models.
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -29,6 +29,19 @@
       and wetland restoration, and biomass burial. Emissions reported in this 
       category represent fluxes to/from the atmosphere from/to the land pool.
     unit: "{Level-2 Species}"
+- Gross Emissions|CO2|AFOLU:
+  description: Gross emissions of carbon dioxide (CO2), i.e. the sum of all positive emissions 
+      (excluding all negative emissions), from agriculture, forestry
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3). Emissions reported in this 
+      category represent fluxes from the land pool to the atmosphere.
+  unit: Mt CO2/yr
+- Gross Emissions|CO2|AFOLU|Deforestation:
+  description: Gross emissions of carbon dioxide (CO2) from deforestation
+- Gross Emissions|CO2|AFOLU|Other Land:
+  description: Gross emissions of carbon dioxide (CO2) from other land-use change
+- Gross Emissions|CO2|AFOLU|Forest Management:
+  description: Gross emissions of carbon dioxide (CO2) from forest management
+
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
     unit: "{Level-3 Species}"
@@ -67,19 +80,6 @@
     description: Emissions and removals of {Level-3 Species} from rangelands and pasture land
       (IPCC category 3B3)  (DESCRIPTION TO BE UPDATED)
     unit: "{Level-3 Species}"
-
-- Gross Emissions|CO2|AFOLU:
-  description: Gross emissions of carbon dioxide (CO2), i.e. the sum of all positive emissions 
-      (excluding all negative emissions), from agriculture, forestry
-      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3). Emissions reported in this 
-      category represent fluxes from the land pool to the atmosphere.
-  unit: Mt CO2/yr
-- Gross Emissions|CO2|AFOLU|Deforestation:
-  description: Gross emissions of carbon dioxide (CO2) from deforestation
-- Gross Emissions|CO2|AFOLU|Other Land:
-  description: Gross emissions of carbon dioxide (CO2) from other land-use change
-- Gross Emissions|CO2|AFOLU|Forest Management:
-  description: Gross emissions of carbon dioxide (CO2) from forest management
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -91,9 +91,6 @@
       land use change. Removals in this variable include agroforestry, re/afforestation, 
       biochar, soil carbon management and forest management.
     unit: "{Level-3 Species}"
-    notes: Emissions from land use change are reported under the land use type
-      that the land is converted to. For instance, deforestation for the creation
-      of new cropland is reported under "Emissions|*|AFOLU|Land|Cropland".
     components:
       - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands
       - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change
@@ -116,7 +113,7 @@
     unit: "{Level-3 Species}"
     notes: Only includes anthropogenic emissions. Does not include wetlands.
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires:
-    description: Emissions from land fires and deforestation & degradation
+    description: Emissions from land fires and deforestation & degradation fires
     unit: "{Level-3 Species}"
     components:
       - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning
@@ -127,7 +124,7 @@
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Forest Burning:
     description: Emissions from boreal forest fires, temperate forest fires,
-      and tropical deforestation & degradation
+      and tropical deforestation & degradation fires
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
     description: Emissions from savanna, grassland, and shrubland fires

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -80,7 +80,8 @@
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use and 
-      land use change
+      land use change. Removals in this variable include agroforestry, re/afforestation, 
+      biochar, soil carbon management and forest management.
     unit: "{Level-3 Species}"
     notes: Emissions from land use change are reported under the land use type
       that the land is converted to. For instance, deforestation for the creation
@@ -176,7 +177,7 @@
       fugitive emissions from fuels (IPCC category 1A (except manufacturing 1A2 
       and other unspecified 1A5), 1B), reporting the sum of sources and sinks, including negative 
       emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply 
-      and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage
+      and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage and synthetic fuels
     unit: "{Level-2 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
@@ -363,10 +364,10 @@
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:
     description: Capture and removal of atmospheric {Level-3 Species} using other net-negative 
-      technologies that are not directly linked 
-      to an emissions source, including direct air carbon capture and storage (DACCS) or enhanced 
-      weathering (EW), as well as durable wood products in building elements, mineral products, 
-      ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture
+      technologies that are not directly linked to an emissions source, including direct air 
+      carbon capture and storage (DACCS) or enhanced weathering (EW), as well as durable wood 
+      products in building elements or plastics, mineral products, ocean fertilization, 
+      ocean alkalinity enhancement (OAE), and direct ocean capture. 
     unit: "{Level-3 Species}"
     notes: This timeseries should be reported as negative values so that subcategories of
       emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -267,7 +267,9 @@
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:
-    description: Emissions of {Level-2 Species} from other sources, (IPCC category 7, including fossil fuel fires)
+    description: Emissions of {Level-2 Species} from other sources, (IPCC 1996 category 7; IPCC 2006 category 5B; including fossil fuel fires). 
+      Only use this category exceptionally, for any categories than cannot be accommodated in the categories described above. 
+      Unless specified otherwise, this will be treated as a flux from some fossil reservoir to the atmosphere in climate models.
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -21,10 +21,10 @@
       - Emissions|{Level-1 Species}|Product Use
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
-    description: Gross emissions of carbon dioxide (CO2). 
-      This is emissions sources only. All removals (for example, 
-      removals from BECCS or direct air carbon capture and storage (DACCS)) 
-      are not included here. For net emissions, see "Emissions|*".
+    description:  Gross emissions of carbon dioxide (CO2), not accounting for
+      negative  emissions from bioenergy with CCS (BECCS), direct air carbon capture
+      or agriculture, forestry and other land use (AFOLU)
+    notes: For net emissions (accounting for negative emissions), see "Emissions|CO2".
     unit: Mt CO2/yr
 
 - Emissions|{Level-2 Species}|AFOLU:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -35,9 +35,8 @@
       from livestock, rice cultivation and soil management as well as 
       emissions from land use and land-use change (mostly CO2) such as deforestation, 
       conversion of non-forest natural land, and drained peatlands. 
-      This is reporting the sum of sources and sinks including land-use methods that do not 
-      use CCS such as soil carbon sequestration, biochar, forestry, and re/afforestation and 
-      agroforestry. 
+      This is reporting the sum of sources and sinks including land-use methods such as 
+      soil carbon sequestration, biochar, forestry, and re/afforestation and agroforestry. 
     unit: "{Level-2 Species}"
     notes: This variable uses the model/scientific definition of AFOLU, and does 
       not align with the reporting of national greenhouse gas inventories (NGHGI).

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -20,7 +20,7 @@
 
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
-      and other land use (IPCC category 3),  reporting the net of emissions 
+      and other land use (IPCC category 3), reporting the net of emissions 
       including land-use methods that do not use CCS such as soil carbon 
       sequestration, biochar, forestry, peatland and wetland restoration, 
       and biomass burial
@@ -64,6 +64,12 @@
     description: Emissions and removals of {Level-3 Species} from any other categories
       of land burning (e.g. peatlands)
     unit: "{Level-3 Species}"
+
+- Gross Emissions|CO2|AFOLU:
+  description: Gross emissions of {Level-2 Species} from agriculture, forestry
+      and other land use (IPCC category 3), not accounting for 
+      emissions removed from the atmosphere
+  unit: Mt CO2/yr
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -284,8 +284,9 @@
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:
-    description: Emissions of {Level-2 Species} from other sources, (IPCC 1996 category 7; IPCC 2006 category 5B; including fossil fuel fires). 
-      Only use this category exceptionally, for any categories than cannot be accommodated in the categories described above. 
+    description: Emissions of {Level-2 Species} from other sources (IPCC 1996 category 7;
+      IPCC 2006 category 5B) including fossil fuel fires and any sources or sinks that
+      cannot be accommodated in other categories
       notes: This will be treated as a flux from some fossil reservoir to the atmosphere in climate models.
     unit: "{Level-2 Species}"
 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -67,7 +67,7 @@
     description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
     unit: "{Level-3 Species}"
-- Emissions|*|AFOLU|Biomass Burning:
+- Emissions|{Level-3 Species}|AFOLU|Biomass Burning:
     description: Agricultural Waste Burning (DESCRIPTION TO BE UPDATED)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -97,6 +97,9 @@
       carbon capture and removal using BECCS and other forms of CCS on energy forms 
       such Natural Gas, Oil, and Coal, as well as bio-oil storage
     unit: "{Level-2 Species}"
+    components:
+      - Emissions|{Level-3 Species}|Energy|Supply
+      - Emissions|{Level-3 Species}|Energy|Demand
 - Gross Emissions|CO2|Energy:
     description: Gross emissions of carbon dioxide (CO2) from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -27,7 +27,7 @@
       reporting the net of emissions including land-use methods that do not 
       use CCS such as soil carbon sequestration, biochar, forestry, peatland 
       and wetland restoration, and biomass burial. Emissions reported in this 
-      category represent fluxes from the atmosphere to/from the land pool.
+      category represent fluxes to/from the atmosphere from/to the land pool.
     unit: "{Level-2 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
@@ -69,10 +69,17 @@
     unit: "{Level-3 Species}"
 
 - Gross Emissions|CO2|AFOLU:
-  description: Gross emissions of carbon dioxide (CO2) from agriculture, forestry
-      and other land use (IPCC category 3), not accounting for 
-      emissions removed from the atmosphere
+  description: Gross emissions of carbon dioxide (CO2), i.e. the sum of all positive emissions 
+      (excluding all negative emissions), from agriculture, forestry
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3). Emissions reported in this 
+      category represent fluxes from the land pool to the atmosphere.
   unit: Mt CO2/yr
+- Gross Emissions|CO2|AFOLU|Deforestation:
+  description: Gross emissions of carbon dioxide (CO2) from deforestation
+- Gross Emissions|CO2|AFOLU|Other Land:
+  description: Gross emissions of carbon dioxide (CO2) from other land-use change
+- Gross Emissions|CO2|AFOLU|Forest Management:
+  description: Gross emissions of carbon dioxide (CO2) from forest management
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -39,7 +39,10 @@
       use CCS such as soil carbon sequestration, biochar, forestry, and re/afforestation and 
       agroforestry. 
     unit: "{Level-2 Species}"
-    notes: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
+    notes: This variable uses the model/scientific definition of AFOLU, and does 
+      not align with the reporting of national greenhouse gas inventories (NGHGI).
+      For the NGHGI variable reporting, please see "Emissions|*|AFOLU [NGHGI]". 
+      Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
       For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-2 Species}|AFOLU|Agriculture
@@ -138,6 +141,16 @@
       accommodated in other categories (no clear IPCC 1996 category; 
       IPCC 2006 category 3D2) 
     unit: "{Level-3 Species}"
+
+- Emissions|{Level-2 Species}|AFOLU [NGHGI]:
+    description: Emissions of {Level-2 Species} from agriculture, forestry
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3) in line
+      with the national greenhouse gas inventories (NGHGI). 
+    unit: "{Level-2 Species}"
+    notes: This variable is optional, for instance used for comparison with national 
+      greenhouse gas inventories, but is not used for driving climate model simulations,
+      and also not a component of "Emissions|*",  for which the variable "Emissions|*|AFOLU" 
+      with model/scientific definition is used.
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -6,7 +6,11 @@
 # 1996 categories: https://github.com/primap-community/climate_categories/blob/main/climate_categories/data/IPCC1996.yaml
 
 - Emissions|{Level-1 Species}:
-    description: Emissions of {Level-1 Species}, net of emissions to the atmosphere and the removal of {Level-1 Species} from the atmosphere.
+    description: Emissions of {Level-1 Species} to the atmosphere. 
+      For the avoidance of doubt, these emissions are net emissions 
+      (i.e. include both positive (emission) and negative (removal) 
+      contributions. For positive contributions only, see 
+      "Gross Emissions|*").
     unit: "{Level-1 Species}"
     components:
       - Emissions|{Level-1 Species}|AFOLU
@@ -24,7 +28,7 @@
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3), 
-      reporting the net of emissions including land-use methods that do not 
+      reporting the sum of sources and sinks including land-use methods that do not 
       use CCS such as soil carbon sequestration, biochar, forestry, peatland 
       and wetland restoration, and biomass burial. Emissions reported in this 
       category represent fluxes to/from the atmosphere from/to the land pool.
@@ -84,8 +88,8 @@
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
-      including emissions from international bunker fuels, net of negative emissions
-      from bioenergy with CCS (BECCS) in these sectors
+      including emissions from international bunker fuels. This is the sum of sources and sinks, and 
+      includes negative emisisons in these sectors, for instance from bioenergy with CCS (BECCS)
     unit: "{Level-3 Species}"
     components:
       - Emissions|{Level-3 Species}|Energy
@@ -103,9 +107,9 @@
 - Emissions|{Level-2 Species}|Energy:
     description: Emissions of carbon dioxide (CO2) from energy use, including 
       fugitive emissions from fuels (IPCC category 1A (except manufacturing 1A2 
-      and other unspecified 1A5), 1B), reporting the net of energy emissions and 
-      carbon capture and removal using BECCS and other forms of CCS on energy forms 
-      such Natural Gas, Oil, and Coal, as well as bio-oil storage
+      and other unspecified 1A5), 1B), reporting the sum of sources and sinks, including negative 
+      emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply 
+      and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage
     unit: "{Level-2 Species}"
     components:
       - Emissions|{Level-3 Species}|Energy|Supply
@@ -178,8 +182,9 @@
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2),
       residential, commercial, institutional sectors and agriculture, forestry,
       fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and the transportation sector
-      (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
-      net of negative emissions incl. demand-side use of bioenergy with CCS (BECCS)
+      (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei).
+      This is the sum of sources and sinks, including negative emissions such as the demand-side use 
+      of bioenergy with CCS (BECCS)
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
@@ -237,8 +242,9 @@
 
 - Emissions|{Level-3 Species}|Industrial Processes:
     description: Emissions of {Level-3 Species} from industrial processes
-      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), net of negative emissions 
-      using CCS such as from cement production
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E). This is the sum of sources 
+      and sinks, including negative emissions such as those from cement carbonation
+      processes and other forms of capture and storage on industrial processes
     unit: "{Level-3 Species}"
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -6,10 +6,10 @@
 # 1996 categories: https://github.com/primap-community/climate_categories/blob/main/climate_categories/data/IPCC1996.yaml
 
 - Emissions|{Level-1 Species}:
-    description: Emissions of {Level-1 Species} to the atmosphere. 
-      For the avoidance of doubt, these emissions are net emissions 
-      (i.e. include both positive (emission) and negative (removal) 
-      contributions. For positive contributions only, see 
+    description: Emissions of {Level-1 Species} to the atmosphere.
+      For the avoidance of doubt, these emissions are net emissions
+      (i.e. include both positive (emission) and negative (removal)
+      contributions. For positive contributions only, see
       "Gross Emissions|*").
     unit: "{Level-1 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
@@ -22,7 +22,7 @@
       - Emissions|{Level-1 Species}|Product Use
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
-    description:  Gross emissions of carbon dioxide (CO2), not accounting for
+    description: Gross emissions of carbon dioxide (CO2), not accounting for
       negative emissions, for example from bioenergy with CCS (BECCS), direct air carbon capture
       or agriculture, forestry and other land use (AFOLU)
     notes: For net emissions (accounting for negative emissions), see "Emissions|CO2".
@@ -31,17 +31,17 @@
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
-      In particular, this includes agricultural emissions (mostly non-CO2) 
-      from livestock, rice cultivation and soil management as well as 
-      emissions from land use and land-use change (mostly CO2) such as deforestation, 
-      conversion of non-forest natural land, and drained peatlands. 
-      This is reporting the sum of sources and sinks including land-use methods such as 
-      soil carbon sequestration, biochar, forestry, and re/afforestation and agroforestry. 
+      In particular, this includes agricultural emissions (mostly non-CO2)
+      from livestock, rice cultivation and soil management as well as
+      emissions from land use and land-use change (mostly CO2) such as deforestation,
+      conversion of non-forest natural land, and drained peatlands.
+      This is reporting the sum of sources and sinks including land-use methods such as
+      soil carbon sequestration, biochar, forestry, and re/afforestation and agroforestry.
     unit: "{Level-2 Species}"
-    notes: This variable uses the model/scientific definition of AFOLU, and does 
+    notes: This variable uses the model/scientific definition of AFOLU, and does
       not align with the reporting of national greenhouse gas inventories (NGHGI).
-      For the NGHGI variable reporting, please see "Emissions|*|AFOLU [NGHGI]". 
-      Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
+      For the NGHGI variable reporting, please see "Emissions|*|AFOLU [NGHGI]".
+      Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool.
       For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-2 Species}|AFOLU|Agriculture
@@ -50,9 +50,9 @@
 - Gross Emissions|CO2|AFOLU:
     description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
-      This is emissions sources only. All removals (for example, 
-      removals from biochar) are not included here. For net emissions, 
-      see "Emissions|CO2|AFOLU". Emissions reported in this category represent 
+      This is emissions sources only. All removals (for example,
+      removals from biochar) are not included here. For net emissions,
+      see "Emissions|CO2|AFOLU". Emissions reported in this category represent
       fluxes from the land pool to the atmosphere.
     unit: Mt CO2/yr
 
@@ -89,8 +89,8 @@
     unit: "{Level-3 Species}"
     notes: Also sometimes known as 'biomass burning' or 'open agricultural burning'
 - Emissions|{Level-3 Species}|AFOLU|Land:
-    description: Emissions of {Level-3 Species} from forestry and other land use and 
-      land use change. Removals in this variable include agroforestry, re/afforestation, 
+    description: Emissions of {Level-3 Species} from forestry and other land use and
+      land use change. Removals in this variable include agroforestry, re/afforestation,
       biochar, soil carbon management and forest management.
     unit: "{Level-3 Species}"
     components:
@@ -103,15 +103,15 @@
     description: Emissions from land that is covered or saturated by water for
       all or part of the year (e.g., peatland) and that does not fall
       into the forest land, cropland, grassland or settlements
-      categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4) 
-    notes: Includes reservoirs as a managed sub-division and 
-      natural rivers and lakes as unmanaged sub-divisions. Includes drained 
+      categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4)
+    notes: Includes reservoirs as a managed sub-division and
+      natural rivers and lakes as unmanaged sub-divisions. Includes drained
       and rewetted wetlands, does not include natural emissions from intact wetlands.
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change:
     description: Emissions and removals from forest land, cropland, grassland,
       settlements, and other land that cannot be accommodated in other categories
-      (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4). 
+      (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4).
     unit: "{Level-3 Species}"
     notes: Only includes anthropogenic emissions. Does not include wetlands.
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires:
@@ -130,31 +130,31 @@
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
     description: Emissions from savanna, grassland, and shrubland fires
-    unit: "{Level-3 Species}"  
+    unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products:
     description: Emissions and removals from harvested wood products (HWP)
       (no clear IPCC 1996 category; IPCC 2006 category 3D1)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Other:
-    description: Emissions and removals from land that cannot be 
-      accommodated in other categories (no clear IPCC 1996 category; 
-      IPCC 2006 category 3D2) 
+    description: Emissions and removals from land that cannot be
+      accommodated in other categories (no clear IPCC 1996 category;
+      IPCC 2006 category 3D2)
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-2 Species}|AFOLU [NGHGI]:
     description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3) in line
-      with the national greenhouse gas inventories (NGHGI). 
+      with the national greenhouse gas inventories (NGHGI).
     unit: "{Level-2 Species}"
-    notes: This variable is optional, for instance used for comparison with national 
+    notes: This variable is optional, for instance used for comparison with national
       greenhouse gas inventories, but is not used for driving climate model simulations,
-      and also not a component of "Emissions|*",  for which the variable "Emissions|*|AFOLU" 
+      and also not a component of "Emissions|*",  for which the variable "Emissions|*|AFOLU"
       with model/scientific definition is used.
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
-      including emissions from international bunker fuels. This is the sum of sources and sinks, and 
+      including emissions from international bunker fuels. This is the sum of sources and sinks, and
       includes negative emisisons in these sectors, for instance from bioenergy with CCS (BECCS)
     unit: "{Level-3 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
@@ -164,7 +164,7 @@
 - Gross Emissions|CO2|Energy and Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
       (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
-      including emissions from international bunker fuels, not accounting for 
+      including emissions from international bunker fuels, not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
     components:
@@ -172,10 +172,10 @@
       - Gross Emissions|CO2|Industrial Processes
 
 - Emissions|{Level-2 Species}|Energy:
-    description: Emissions of carbon dioxide (CO2) from energy use, including 
-      fugitive emissions from fuels (IPCC category 1A (except manufacturing 1A2 
-      and other unspecified 1A5), 1B), reporting the sum of sources and sinks, including negative 
-      emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply 
+    description: Emissions of carbon dioxide (CO2) from energy use, including
+      fugitive emissions from fuels (IPCC category 1A (except manufacturing 1A2
+      and other unspecified 1A5), 1B), reporting the sum of sources and sinks, including negative
+      emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply
       and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage and synthetic fuels
     unit: "{Level-2 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
@@ -184,7 +184,7 @@
       - Emissions|{Level-2 Species}|Energy|Demand
 - Gross Emissions|CO2|Energy:
     description: Gross emissions of carbon dioxide (CO2) from energy use,
-      including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for 
+      including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply:
@@ -201,7 +201,7 @@
       other energy conversion (e.g., refineries, synfuel production, solid fuel processing,
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei),
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
-      transport and storage (IPCC category 1C), not accounting for 
+      transport and storage (IPCC category 1C), not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply|Combustion:
@@ -251,7 +251,7 @@
       residential, commercial, institutional sectors and agriculture, forestry,
       fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and the transportation sector
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei).
-      This is the sum of sources and sinks, including negative emissions such as the demand-side use 
+      This is the sum of sources and sinks, including negative emissions such as the demand-side use
       of bioenergy with CCS (BECCS)
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand:
@@ -310,14 +310,14 @@
 
 - Emissions|{Level-3 Species}|Industrial Processes:
     description: Emissions of {Level-3 Species} from industrial processes
-      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E). This is the sum of sources 
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E). This is the sum of sources
       and sinks, including negative emissions such as those from cement carbonation
       processes and other forms of capture and storage on industrial processes
     unit: "{Level-3 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
-      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions 
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions
       from carbon removal processes such as from cement production
     unit: Mt CO2/yr
 - Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}:
@@ -350,7 +350,7 @@
 
 - Emissions|{Level-2 Species}|Waste:
     description: Emissions of {Level-2 Species} from waste of fossil-based products
-      through incineration or decomposition (IPCC 1996 category 6; IPCC 2006 category 4), 
+      through incineration or decomposition (IPCC 1996 category 6; IPCC 2006 category 4),
       not including emissions from organic waste handling and decay
     unit: "{Level-2 Species}"
 
@@ -362,12 +362,12 @@
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:
-    description: Capture and removal of atmospheric {Level-3 Species} using other net-negative 
-      technologies that are not directly linked to an emissions source, including direct air 
-      carbon capture and storage (DACCS) or enhanced weathering (EW), as well as durable wood 
-      products in building elements or plastics, mineral products, ocean fertilization, 
-      ocean alkalinity enhancement (OAE), and direct ocean capture. 
+    description: Capture and removal of atmospheric {Level-3 Species} using other net-negative
+      technologies that are not directly linked to an emissions source, including direct air
+      carbon capture and storage (DACCS) or enhanced weathering (EW), as well as durable wood
+      products in building elements or plastics, mineral products, ocean fertilization,
+      ocean alkalinity enhancement (OAE), and direct ocean capture.
     unit: "{Level-3 Species}"
     notes: This timeseries should be reported as negative values so that subcategories of
-      emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon 
+      emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon
       removals, see the "Carbon Removal|*" tree

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -37,6 +37,10 @@
       category represent fluxes to/from the atmosphere from/to the land pool.
     unit: "{Level-2 Species}"
     note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    components:
+      - Emissions|{Level-3 Species}|AFOLU|Agriculture
+      - Emissions|{Level-3 Species}|AFOLU|Biomass Burning
+      - Emissions|{Level-3 Species}|AFOLU|Land
 - Gross Emissions|CO2|AFOLU:
   description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
@@ -73,6 +77,14 @@
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use
     unit: "{Level-3 Species}"
+    components:
+      - Emissions|{Level-3 Species}|AFOLU|Land|Forest Land
+      - Emissions|{Level-3 Species}|AFOLU|Land|Cropland
+      - Emissions|{Level-3 Species}|AFOLU|Land|Grassland
+      - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands
+      - Emissions|{Level-3 Species}|AFOLU|Land|Settlements
+      - Emissions|{Level-3 Species}|AFOLU|Land|Other Land
+      - Emissions|{Level-3 Species}|AFOLU|Land|Fires
 - Emissions|{Level-3 Species}|AFOLU|Land|Forest Land:
     description: Emissions and removals from lands with woody vegetation
       (partially IPCC 1996 category 5A/5B/5D; IPCC 2006 category 3B1) 
@@ -117,6 +129,9 @@
       unmanaged land areas that do not fall into any of the other
       land categories (no clear IPCC 1996 category; IPCC 2006 category 3B6). 
     unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Fires:
+    description: Emissions from land fires and deforestation & degradation
+    unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning:
     description: Emissions from peat fires
     unit: "{Level-3 Species}"
@@ -125,7 +140,7 @@
       and tropical deforestation & degradation
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
-    description: Emissions from 
+    description: Emissions from savanna, grassland, and shrubland fires
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -65,7 +65,7 @@
     unit: "{Level-3 Species}"
 
 - Gross Emissions|CO2|AFOLU:
-  description: Gross emissions of {Level-2 Species} from agriculture, forestry
+  description: Gross emissions of carbon dioxide (CO2) from agriculture, forestry
       and other land use (IPCC category 3), not accounting for 
       emissions removed from the atmosphere
   unit: Mt CO2/yr

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -11,6 +11,7 @@
       - Emissions|{Level-1 Species}|Industrial Processes
       - Emissions|{Level-1 Species}|Waste
       - Emissions|{Level-1 Species}|Other Capture and Removal
+      - Emissions|{Level-1 Species}|Product Use
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
     description: Gross emissions of carbon dioxide (CO2), not accounting for 
@@ -255,10 +256,6 @@
 
 - Emissions|{Level-2 Species}|Waste:
     description: Emissions of {Level-2 Species} from waste (IPCC category 6)
-    unit: "{Level-2 Species}"
-
-- Emissions|{Level-2 Species}|Fossil Fuel Fires:
-    description: Emissions of {Level-2 Species} from fossil fuel fires (IPCC category 7)
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -263,7 +263,9 @@
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-2 Species}|Waste:
-    description: Emissions of {Level-2 Species} from waste (IPCC category 6)
+    description: Emissions of {Level-2 Species} from waste (IPCC 1996 category 6; IPCC 2006 category 4). 
+      Any emissions from fossil-based products (incineration or CO2 decomposition) should be accounted for here.
+      CO2 from organic waste handling and decay should not be included.
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -46,23 +46,22 @@
     description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
     unit: "{Level-3 Species}"
+- Emissions|*|AFOLU|Biomass Burning:
+    description: Agricultural Waste Burning (DESCRIPTION TO BE UPDATED)
+    unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
-    description: Emissions of {Level-3 Species} from managed peatlands (drained and rewetted)
+- Emissions|{Level-3 Species}|AFOLU|Land|Peat Burning:
+    description: Emissions of {Level-3 Species} from managed peatlands (drained and rewetted)  (DESCRIPTION TO BE UPDATED)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Forest Burning:
-    description: Emissions and removals of {Level-3 Species} from land with woody vegetation
-      (forests, IPCC category 3B1)
+    description: Emissions and removals of {Level-3 Species} from land with woody vegetation 
+      (forests, IPCC category 3B1)  (DESCRIPTION TO BE UPDATED)
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Grassland Burning:
     description: Emissions and removals of {Level-3 Species} from rangelands and pasture land
-      (IPCC category 3B3)
-    unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Other Land Burning:
-    description: Emissions and removals of {Level-3 Species} from any other categories
-      of land burning (e.g. peatlands)
+      (IPCC category 3B3)  (DESCRIPTION TO BE UPDATED)
     unit: "{Level-3 Species}"
 
 - Gross Emissions|CO2|AFOLU:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -23,10 +23,11 @@
 
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
-      and other land use (IPCC category 3), reporting the net of emissions 
-      including land-use methods that do not use CCS such as soil carbon 
-      sequestration, biochar, forestry, peatland and wetland restoration, 
-      and biomass burial
+      and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3), 
+      reporting the net of emissions including land-use methods that do not 
+      use CCS such as soil carbon sequestration, biochar, forestry, peatland 
+      and wetland restoration, and biomass burial. Emissions reported in this 
+      category represent fluxes from the atmosphere to/from the land pool.
     unit: "{Level-2 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -39,7 +39,8 @@
       use CCS such as soil carbon sequestration, biochar, forestry, and re/afforestation and 
       agroforestry. 
     unit: "{Level-2 Species}"
-    note: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. For a breakdown of carbon removals, see the "Carbon Removal|*" tree
+    note: Emissions reported in this category represent fluxes to/from the atmosphere from/to the land pool. 
+      For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|AFOLU|Agriculture
       - Emissions|{Level-3 Species}|AFOLU|Biomass Burning
@@ -78,8 +79,12 @@
     description: Emissions from agricultural waste burning
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land:
-    description: Emissions of {Level-3 Species} from forestry and other land use
+    description: Emissions of {Level-3 Species} from forestry and other land use and 
+      land use change
     unit: "{Level-3 Species}"
+    note: Emissions from land use change are reported under the land use type
+      that the land is converted to. For instance, deforestation for the creation
+      of new cropland is reported under "Emissions|*|AFOLU|Land|Cropland".
     components:
       - Emissions|{Level-3 Species}|AFOLU|Land|Forest Land
       - Emissions|{Level-3 Species}|AFOLU|Land|Cropland

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -68,21 +68,64 @@
       in the agriculture sector
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Biomass Burning:
-    description: Agricultural Waste Burning (DESCRIPTION TO BE UPDATED)
+    description: Emissions from agricultural waste burning
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Peat Burning:
-    description: Emissions of {Level-3 Species} from managed peatlands (drained and rewetted)  (DESCRIPTION TO BE UPDATED)
+- Emissions|{Level-3 Species}|AFOLU|Land|Forest Land:
+    description: Emissions and removals from lands with woody vegetation
+      (partially IPCC 1996 category 5A/5B/5D; IPCC 2006 category 3B1) 
+    note: It also includes systems with vegetation that currently fall below, 
+      but are expected to later exceed, the threshold values used by a country to
+      define the forest land category.
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Forest Burning:
-    description: Emissions and removals of {Level-3 Species} from land with woody vegetation 
-      (forests, IPCC category 3B1)  (DESCRIPTION TO BE UPDATED)
+- Emissions|{Level-3 Species}|AFOLU|Land|Cropland:
+    description: Emissions and removals from arable and tillage land, rice
+      fields, and agro-forestry systems where vegetation falls
+      below the thresholds used for the forest land category
+      (no clear IPCC 1996 category; IPCC 2006 category 3B2)
+    note: This does not include methane emissions from rice cultivation
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Grassland Burning:
-    description: Emissions and removals of {Level-3 Species} from rangelands and pasture land
-      (IPCC category 3B3)  (DESCRIPTION TO BE UPDATED)
+- Emissions|{Level-3 Species}|AFOLU|Land|Grassland:
+    description: Emissions and removals from rangelands and pasture land
+      that is not considered cropland. It also includes systems with
+      woody vegetation that fall below the threshold values used
+      in the forest land category and are not expected to exceed
+      them, without human intervention (partially IPCC 1996 category 4D/4E/5A/5B/5C/5D; IPCC 2006 category 3B3).
+    note: The category also includes all grassland from wild lands to recreational 
+      areas as well as agricultural and silvi-pastural systems, subdivided
+      into managed and unmanaged, consistent with national
+      definitions.
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
+    description: Emissions from land that is covered or saturated by water for
+      all or part of the year (e.g., peatland) and that does not fall
+      into the forest land, cropland, grassland or settlements
+      categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4) 
+    note: It includes reservoirs as a managed sub-division and 
+      natural rivers and lakes as unmanaged sub-divisions
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Settlements:
+    description: Emissions and removals from all developed land, including
+      transportation infrastructure and human settlements of any
+      size, unless they are already included under other
+      categories (partially IPCC 1996 category 5A/5B/5D/5E; IPCC 2006 category 3B5).
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Other Land:
+    description: Emissions and removals from bare soil, rock, ice, and all
+      unmanaged land areas that do not fall into any of the other
+      land categories (no clear IPCC 1996 category; IPCC 2006 category 3B6). 
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning:
+    description: Emissions from peat fires
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Fires|Forest Burning:
+    description: Emissions from boreal forest fires, temperate forest fires,
+      and tropical deforestation & degradation
+    unit: "{Level-3 Species}"
+- Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
+    description: Emissions from 
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -3,24 +3,26 @@
 # Gross emissions are only defined for CO2.
 
 - Emissions|{Level-1 Species}:
-    description: Emissions of {Level-1 Species}
+    description: Emissions of {Level-1 Species}, net of emissions to the atmosphere and the removal of {Level-1 Species} from the atmosphere.
     unit: "{Level-1 Species}"
     components:
       - Emissions|{Level-1 Species}|AFOLU
       - Emissions|{Level-1 Species}|Energy
       - Emissions|{Level-1 Species}|Industrial Processes
       - Emissions|{Level-1 Species}|Waste
-      - Emissions|{Level-1 Species}|Capture and Removal
+      - Emissions|{Level-1 Species}|Other Capture and Removal
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
-    description: Gross emissions of carbon dioxide (CO2), not accounting for negative
-      emissions from bioenergy with CCS (BECCS) or agriculture, forestry
-      and other land use (AFOLU)
+    description: Gross emissions of carbon dioxide (CO2), not accounting for 
+      emissions removed from the atmosphere
     unit: Mt CO2/yr
 
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
-      and other land use (IPCC category 3)
+      and other land use (IPCC category 3),  reporting the net of emissions 
+      including land-use methods that do not use CCS such as soil carbon 
+      sequestration, biochar, forestry, peatland and wetland restoration, 
+      and biomass burial
     unit: "{Level-2 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
@@ -64,7 +66,7 @@
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
     description: Emissions of {Level-3 Species} from energy use in supply and demand sectors
-      (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
+      (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
       including emissions from international bunker fuels, net of negative emissions
       from bioenergy with CCS (BECCS) in these sectors
     unit: "{Level-3 Species}"
@@ -73,22 +75,25 @@
       - Emissions|{Level-3 Species}|Industrial Processes
 - Gross Emissions|CO2|Energy and Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from energy use in supply and demand sectors
-      (IPCC category 1A, 1B) and from industrial processes (IPCC categories 2A, B, C, E),
-      including emissions from international bunker fuels, not accounting for
-      negative emissions from bioenergy with CCS (BECCS) in these sectors
+      (IPCC category 1A, 1B) and from industrial processes (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E),
+      including emissions from international bunker fuels, not accounting for 
+      emissions removed from the atmosphere
     unit: Mt CO2/yr
     components:
       - Gross Emissions|CO2|Energy
       - Gross Emissions|CO2|Industrial Processes
 
 - Emissions|{Level-2 Species}|Energy:
-    description: Emissions of {Level-2 Species} from energy use,
-      including fugitive emissions from fuels (IPCC category 1A, 1B)
+    description: Emissions of carbon dioxide (CO2) from energy use, including 
+      fugitive emissions from fuels (IPCC category 1A (except manufacturing 1A2 
+      and other unspecified 1A5), 1B), reporting the net of energy emissions and 
+      carbon capture and removal using BECCS and other forms of CCS on energy forms 
+      such Natural Gas, Oil, and Coal, as well as bio-oil storage
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy:
     description: Gross emissions of carbon dioxide (CO2) from energy use,
-      including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for
-      negative emissions from bioenergy with CCS (BECCS) in these sectors
+      including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for 
+      emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply:
     description: Emissions of {Level-2 Species} from fuel combustion and fugitive emissions
@@ -104,8 +109,8 @@
       other energy conversion (e.g., refineries, synfuel production, solid fuel processing,
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei),
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
-      transport and storage (IPCC category 1C), not accounting for negative emissions
-      from bioenergy with CCS (BECCS) in these sectors
+      transport and storage (IPCC category 1C), not accounting for 
+      emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply|Combustion:
     description: Emissions of {Level-2 Species} from fuel combustion in energy supply,
@@ -123,7 +128,7 @@
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Electricity:
     description: Gross emissions of carbon dioxide (CO2) for electricity generation,
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2}
@@ -131,7 +136,7 @@
     tier: "{Secondary Fuel Level 2}"
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
     tier: "{Secondary Fuel Level 2}"
 - Emissions|CO2|Energy|Supply|Autoproduction:
@@ -139,14 +144,14 @@
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Autoproduction:
     description: Gross emissions of carbon dioxide (CO2) for own-use energy supply,
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in this sector
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|Other:
     description: Emissions of carbon dioxide (CO2) for other categories of energy supply
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Other:
     description: Gross emissions of carbon dioxide (CO2) for other categories of energy supply,
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
 
 - Emissions|{Level-2 Species}|Energy|Demand:
@@ -161,14 +166,14 @@
       residential, commercial, institutional sectors and agriculture, forestry,
       fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and the transportation sector
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Demand|Industry:
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)
     unit: "{Level-2 Species}"
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
-      not accounting for negative emissions from bioenergy with CCS (BECCS) in these sectors
+      not accounting for emissions removed from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
@@ -212,20 +217,21 @@
 
 - Emissions|{Level-3 Species}|Industrial Processes:
     description: Emissions of {Level-3 Species} from industrial processes
-      (IPCC categories 2A, B, C, E), net of negative emissions using CCS
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), net of negative emissions 
+      using CCS such as from cement production
     unit: "{Level-3 Species}"
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
-      (IPCC categories 2A, B, C, E), not accounting for negative emissions from
-      bioenergy with CCS (BECCS) in these sectors
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions 
+      from carbon removal processes such as from cement production
     unit: Mt CO2/yr
 - Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}:
     description: Emissions of {Level-3 Species} from industrial processes
-      (IPCC categories 2A, B, C, E) in the {Non-Energy Sector}
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Non-Energy Sector}
     unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|Industrial Processes|{Industrial-Process Sector}:
     description: Emissions of {Level-3 Species} from industrial processes
-      (IPCC categories 2A, B, C, E) in the {Industrial-Process Sector}
+      (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Industrial-Process Sector}
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-3 Species}|Product Use:
@@ -256,13 +262,16 @@
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:
-    description: Emissions of {Level-2 Species} from other sources
+    description: Emissions of {Level-2 Species} from other sources, (IPCC category 7, including fossil fuel fires)
     unit: "{Level-2 Species}"
 
-- Emissions|{Level-3 Species}|Capture and Removal:
-    description: Capture and removal of atmospheric {Level-3 Species} using net-negative
-      technologies that are not directly linked to an emissions source,
-      e.g., direct air capture (DAC) or enhanced weathering
+- Emissions|{Level-3 Species}|Other Capture and Removal:
+    description: Capture and removal of atmospheric {Level-3 Species} using other net-negative 
+      technologies that are not reported under other variables as they are not directly linked 
+      to an emissions source, including direct air carbon capture and storage (DACCS) or enhanced 
+      weathering (EW), as well as durable wood products in building elements, mineral products, 
+      ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture, 
+      and other methods
     unit: "{Level-3 Species}"
     note: This timeseries should be reported as negative values so that subcategories of
       emissions add up to net emissions `Emissions|{Level-3 Species}`.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -48,13 +48,13 @@
       - Emissions|{Level-2 Species}|AFOLU|Agricultural Waste Burning
       - Emissions|{Level-2 Species}|AFOLU|Land
 - Gross Emissions|CO2|AFOLU:
-  description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
+    description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
       This is emissions sources only. All removals (for example, 
       removals from biochar) are not included here. For net emissions, 
       see "Emissions|CO2|AFOLU". Emissions reported in this category represent 
       fluxes from the land pool to the atmosphere.
-  unit: Mt CO2/yr
+    unit: Mt CO2/yr
 
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
@@ -180,8 +180,8 @@
     unit: "{Level-2 Species}"
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
-      - Emissions|{Level-3 Species}|Energy|Supply
-      - Emissions|{Level-3 Species}|Energy|Demand
+      - Emissions|{Level-2 Species}|Energy|Supply
+      - Emissions|{Level-2 Species}|Energy|Demand
 - Gross Emissions|CO2|Energy:
     description: Gross emissions of carbon dioxide (CO2) from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -278,9 +278,9 @@
     unit: "{Level-3 Species}"
 
 - Emissions|{Level-2 Species}|Waste:
-    description: Emissions of {Level-2 Species} from waste (IPCC 1996 category 6; IPCC 2006 category 4). 
-      Any emissions from fossil-based products (incineration or CO2 decomposition) should be accounted for here.
-      CO2 from organic waste handling and decay should not be included.
+    description: Emissions of {Level-2 Species} from waste of fossil-based products
+      through incineration or decomposition (IPCC 1996 category 6; IPCC 2006 category 4), 
+      not including emissions from organic waste handling and decay
     unit: "{Level-2 Species}"
 
 - Emissions|{Level-2 Species}|Other:

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -95,16 +95,12 @@
       that the land is converted to. For instance, deforestation for the creation
       of new cropland is reported under "Emissions|*|AFOLU|Land|Cropland".
     components:
-      - Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change
+      - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands
+      - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change
       - Emissions|{Level-3 Species}|AFOLU|Land|Fires
       - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
-- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change:
-    description: Emissions and removals from land use and land-use change,
-      including emissions from deforestation and conversion from all other natural land,
-      as well as removals from the atmosphere through agroforestry or re/afforestation
-    unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change|Wetlands:
+- Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
     description: Emissions from land that is covered or saturated by water for
       all or part of the year (e.g., peatland) and that does not fall
       into the forest land, cropland, grassland or settlements
@@ -113,7 +109,7 @@
       natural rivers and lakes as unmanaged sub-divisions. Includes drained 
       and rewetted wetlands, does not include natural emissions from intact wetlands.
     unit: "{Level-3 Species}"
-- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change|Other:
+- Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change:
     description: Emissions and removals from forest land, cropland, grassland,
       settlements, and other land that cannot be accommodated in other categories
       (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4). 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -12,6 +12,7 @@
       contributions. For positive contributions only, see 
       "Gross Emissions|*").
     unit: "{Level-1 Species}"
+    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-1 Species}|AFOLU
       - Emissions|{Level-1 Species}|Energy
@@ -35,6 +36,7 @@
       and wetland restoration, and biomass burial. Emissions reported in this 
       category represent fluxes to/from the atmosphere from/to the land pool.
     unit: "{Level-2 Species}"
+    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
 - Gross Emissions|CO2|AFOLU:
   description: Gross emissions of carbon dioxide (CO2)  from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3).
@@ -89,6 +91,7 @@
       including emissions from international bunker fuels. This is the sum of sources and sinks, and 
       includes negative emisisons in these sectors, for instance from bioenergy with CCS (BECCS)
     unit: "{Level-3 Species}"
+    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|Energy
       - Emissions|{Level-3 Species}|Industrial Processes
@@ -109,6 +112,7 @@
       emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply 
       and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage
     unit: "{Level-2 Species}"
+    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|Energy|Supply
       - Emissions|{Level-3 Species}|Energy|Demand
@@ -244,6 +248,7 @@
       and sinks, including negative emissions such as those from cement carbonation
       processes and other forms of capture and storage on industrial processes
     unit: "{Level-3 Species}"
+    note: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions 
@@ -298,4 +303,5 @@
       ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture
     unit: "{Level-3 Species}"
     note: This timeseries should be reported as negative values so that subcategories of
-      emissions add up to net emissions `Emissions|{Level-3 Species}`.
+      emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon 
+      removals, see the "Carbon Removal|*" tree

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -22,7 +22,7 @@
       - Emissions|{Level-1 Species}|Other
 - Gross Emissions|CO2:
     description:  Gross emissions of carbon dioxide (CO2), not accounting for
-      negative  emissions from bioenergy with CCS (BECCS), direct air carbon capture
+      negative emissions, for example from bioenergy with CCS (BECCS), direct air carbon capture
       or agriculture, forestry and other land use (AFOLU)
     notes: For net emissions (accounting for negative emissions), see "Emissions|CO2".
     unit: Mt CO2/yr
@@ -115,7 +115,7 @@
 - Gross Emissions|CO2|Energy:
     description: Gross emissions of carbon dioxide (CO2) from energy use,
       including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for 
-      emissions removed from the atmosphere
+      removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply:
     description: Emissions of {Level-2 Species} from fuel combustion and fugitive emissions
@@ -132,7 +132,7 @@
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei),
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
       transport and storage (IPCC category 1C), not accounting for 
-      emissions removed from the atmosphere
+      removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Supply|Combustion:
     description: Emissions of {Level-2 Species} from fuel combustion in energy supply,
@@ -150,7 +150,7 @@
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Electricity:
     description: Gross emissions of carbon dioxide (CO2) for electricity generation,
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2}
@@ -158,7 +158,7 @@
     tier: "{Secondary Fuel Level 2}"
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
     tier: "{Secondary Fuel Level 2}"
 - Emissions|CO2|Energy|Supply|Autoproduction:
@@ -166,14 +166,14 @@
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Autoproduction:
     description: Gross emissions of carbon dioxide (CO2) for own-use energy supply,
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|CO2|Energy|Supply|Other:
     description: Emissions of carbon dioxide (CO2) for other categories of energy supply
     unit: Mt CO2/yr
 - Gross Emissions|CO2|Energy|Supply|Other:
     description: Gross emissions of carbon dioxide (CO2) for other categories of energy supply,
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
 
 - Emissions|{Level-2 Species}|Energy|Demand:
@@ -189,7 +189,7 @@
       residential, commercial, institutional sectors and agriculture, forestry,
       fishing (AFOFI) (IPCC category 1A4a, 1A4b, 1A4c), and the transportation sector
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
-      not accounting for emissions removed from the atmosphere
+      not accounting for removals from the atmosphere
     unit: Mt CO2/yr
 - Emissions|{Level-2 Species}|Energy|Demand|Industry:
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -291,7 +291,7 @@
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:
     description: Capture and removal of atmospheric {Level-3 Species} using other net-negative 
-      technologies that are not reported under other variables as they are not directly linked 
+      technologies that are not directly linked 
       to an emissions source, including direct air carbon capture and storage (DACCS) or enhanced 
       weathering (EW), as well as durable wood products in building elements, mineral products, 
       ocean fertilization, biomass sinking, ocean alkalinity enhancement (OAE), direct ocean capture, 

--- a/definitions/variable/macro-economy/investment.yaml
+++ b/definitions/variable/macro-economy/investment.yaml
@@ -28,13 +28,13 @@
     description: Investments for the production of {Secondary Fuel Level 2}
     unit: billion USD_2010/yr
     tier: "{Secondary Fuel Level 2}"
-    note: For plants equipped with CCS, the investment in the capturing equipment should
+    notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 - Investment|Energy Supply|{Secondary Fuel Level 2}|{CCS}:
     description: Investments for the production of {Secondary Fuel Level 2} {CCS}
     unit: billion USD_2010/yr
     tier: "{Secondary Fuel Level 2}"
-    note: For plants equipped with CCS, the investment in the capturing equipment should
+    notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 
 - Investment|Energy Efficiency:


### PR DESCRIPTION
Implementing the variable list from [here [sheet: IAMC variables]](https://docs.google.com/spreadsheets/d/1HKfl21NX8wohPEHpHlmf5XithknPw8zjLpVe4MiOU9U/edit?usp=sharing)

General context documented under #151 (currently bit outdated).


Should address:

Minimum:
- [x] CDR under "Emissions|*" #145 
    - [x] check consistency with https://github.com/IAMconsortium/common-definitions/pull/172
- [x] High-level (CO2) variables; components Product Use and Fossil Fuel Fires #165 
- [x] Burning variables #167 and #64
    - [x] Update descriptions
- [x] Add "Gross Emissions|CO2|AFOLU" #151 
- [x] Supply + Demand = Total #173
- [ ] merge check: are "level" 1/2/3 components defined consistently between 'component' and the actual variables?

Optional / can leave for future versions:
- [ ] #185 
- [ ] #166
- [ ] #144
- [ ] #187
- [ ] #186 
- [ ] #184 (now domestic aviation would be calculated by adding/subtracting other variables [see here [sheet: IAMC variables]](https://docs.google.com/spreadsheets/d/1HKfl21NX8wohPEHpHlmf5XithknPw8zjLpVe4MiOU9U/edit?usp=sharing))
- [ ] add tier levels (#179)
- [ ] create a 'diff' with the AR6 database template
- [ ] update synfuels guidelines (#49)
- [x] national GHG inventories (#146)
- [ ] consider changing the hierarchy by placing Fires outside of AFOLU (#200)
- [ ] clarify HWP reporting (PR/issue tbd)
- [ ] provide clarity on which sector-species combinations are expected to be zero / not required [e.g. BC|Agriculture] (#202)
- [ ] consider adding CDR methods not only in top-level descriptions, but also to lower-level variable descriptions (PR/issue tbd)
- [ ] reconsider reporting unit for NO2 (NOx / NO2 - NOx may be a bit ambiguous)  (PR/issue tbd)