### PR TITLE
Add price variables for production commodities

### DIFF
--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -1,0 +1,20 @@
+- Price|Production|Iron and Steel|{Iron Commodity}:
+    description: Price of {Iron Commodity}
+    unit: USD_2010/Mt
+    tier: "{Iron Commodity}"
+    navigate: Price|Industry|Iron and Steel|{Iron Commodity}
+    engage: Price|Industry|Iron and Steel|{Iron Commodity}
+
+- Price|Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
+    description: Price of {Non-Ferrous Metals Commodity}
+    unit: USD_2010/Mt
+    tier: "{Non-Ferrous Metals Commodity}"
+    navigate: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
+    engage: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
+
+- Price|Production|Chemicals|{Chemicals Commodity}:
+    description: Price of {Chemicals Commodity}
+    unit: USD_2010/Mt
+    tier: "{Chemicals Commodity}"
+    navigate: Price|Industry|{Chemicals Commodity}
+    engage: Price|Industry|{Chemicals Commodity}

--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -2,6 +2,7 @@
     description: Price of {Iron Commodity}
     unit: USD_2010/Mt
     tier: "{Iron Commodity}"
+    weight: Production|Iron and Steel|{Iron Commodity}
     navigate: Price|Industry|Iron and Steel|{Iron Commodity}
     engage: Price|Industry|Iron and Steel|{Iron Commodity}
 
@@ -9,6 +10,7 @@
     description: Price of {Non-Ferrous Metals Commodity}
     unit: USD_2010/Mt
     tier: "{Non-Ferrous Metals Commodity}"
+    weight: Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
     navigate: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
     engage: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
 
@@ -16,5 +18,6 @@
     description: Price of {Chemicals Commodity}
     unit: USD_2010/Mt
     tier: "{Chemicals Commodity}"
+    weight: Production|Chemicals|{Chemicals Commodity}
     navigate: Price|Industry|{Chemicals Commodity}
     engage: Price|Industry|{Chemicals Commodity}


### PR DESCRIPTION
This PR implements the requested variables via email by @gunnar-pik for prices of industrial commodities - however, given that the related variables are called "Production|...", I propose to rename to "Price|Production|..." instead of "Price|Industry|...".

Please chime in until the end of this week if you have objections.