### PR TITLE
Harmonize descriptions in the AFOLU domain

### DIFF
--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -219,7 +219,7 @@
     unit: Index (2020 = 1)
     weight: Agricultural Production|Crops
     tier: 2
-- Price|Agriculture|Energy crops:
+- Price|Agriculture|Energy Crops:
     description: Farm-gate price of second-generation bioenergy crops 
       (short rotation grasses, short rotation trees)
     unit: USD_2010/GJ

--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -22,7 +22,7 @@
     agmip:
     tier: 2
 - Agricultural Demand|Crops|Bioenergy|2nd generation:
-    description: Demand for second-generation bioenergy crops 
+    description: Demand for second-generation bioenergy crops
       (short rotation grasses, short rotation trees)
     unit: million t DM/yr
     agmip: Domestic use (CONS) - Energy Crops (ECP)
@@ -101,7 +101,7 @@
 
 # Agricultural Production
 - Agricultural Production:
-    description: Total production of food, non-food and feed products 
+    description: Total production of food, non-food and feed products
       (crops and livestock) and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
     agmip: Production (PROD)
@@ -132,7 +132,7 @@
 
 # Agricultural Trade
 - Trade|Agriculture:
-    description: Net export of food, non-food and feed products 
+    description: Net export of food, non-food and feed products
       (crops and livestock) and bioenergy crops (1st & 2nd generation)
     unit: million t DM/yr
     agmip: Production (PROD)
@@ -220,7 +220,7 @@
     weight: Agricultural Production|Crops
     tier: 2
 - Price|Agriculture|Energy Crops:
-    description: Farm-gate price of second-generation bioenergy crops 
+    description: Farm-gate price of second-generation bioenergy crops
       (short rotation grasses, short rotation trees)
     unit: USD_2010/GJ
     weight: Agricultural Production|Crops|Energy Crops

--- a/definitions/variable/afolu/food-system.yaml
+++ b/definitions/variable/afolu/food-system.yaml
@@ -1,5 +1,5 @@
 - Food Availability [per capita]:
-    description: Amount of food available per capita for consumption
+    description: Amount of crops and livestock products available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
@@ -36,7 +36,7 @@
     weight: Population
     tier: 2
 - Food Intake|Crops [per capita]:
-    description: Amount of crops consumed consumed per capita
+    description: Amount of crops consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population

--- a/definitions/variable/afolu/food-system.yaml
+++ b/definitions/variable/afolu/food-system.yaml
@@ -1,69 +1,69 @@
 - Food Availability [per capita]:
-    description: Food available for consumption - crops and livestock products
+    description: Amount of food available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 1
 - Food Availability|Crops [per capita]:
-    description: Food available for consumption - crops
+    description: Amount of crops available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 1
 - Food Availability|Crops|{Crop Types w/o Energy Crops} [per capita]:
-    description: Food available for consumption - {Crop Types w/o Energy Crops}
+    description: Amount of {Crop Types w/o Energy Crops} available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 3
 - Food Availability|Livestock [per capita]:
-    description: Food available for consumption - livestock products
+    description: Amount of livestock products available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 1
 - Food Availability|Livestock|{Livestock Products} [per capita]:
-    description: Food available for consumption - {Livestock Products}
+    description: Amount of {Livestock Products} available per capita for consumption
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 3
 
 - Food Intake [per capita]:
-    description: Food actually consumed - crops and livestock products
+    description: Amount of crops and livestock products consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 2
 - Food Intake|Crops [per capita]:
-    description: Food actually consumed - crops
+    description: Amount of crops consumed consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 2
 - Food Intake|Crops|{Crop Types w/o Energy Crops} [per capita]:
-    description: Food actually consumed - {Crop Types w/o Energy Crops}
+    description: Amount of {Crop Types w/o Energy Crops} consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 3
 - Food Intake|Livestock [per capita]:
-    description: Food actually consumed - livestock products
+    description: Amount of livestock products consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 2
 - Food Intake|Livestock|{Livestock Products} [per capita]:
-    description: Food actually consumed - {Livestock Products}
+    description: Amount of {Livestock Products} consumed per capita
     unit: kcal/cap/day
     sdg: 2
     weight: Population
     tier: 3
 
 - Food Waste [per capita]:
-    description: Amount of food (crops and livestock) per capita that is disposed and 
-      not consumed (difference between food availabilty and food intake) - 
-      includes food losses and food waste
+    description: Amount of food (crops and livestock) per capita that is disposed and
+      not consumed (difference between food availability and food intake),
+      including food losses and food waste
     unit: kcal/cap/day
     sdg: 2
     weight: Population

--- a/definitions/variable/afolu/forestry.yaml
+++ b/definitions/variable/afolu/forestry.yaml
@@ -52,7 +52,7 @@
 
 # Forestry Yield
 - Yield|Forestry|Timber Production:
-    description: Actual timber yield, average on productive forest land. 
+    description: Actual timber yield, average on productive forest land.
       Equals to harvested biomass volume divided by forest area used for timber production
     unit: m3/ha
     weight: Harvested Area|Forestry
@@ -60,7 +60,7 @@
 
 # Forestry Harvested Area
 - Harvested Area|Forestry:
-    description: Total timber harvest/production area 
+    description: Total timber harvest/production area
       (= sum of timber plantations, and other productive forest that is being harvested)
     unit: million ha/yr
     tier: 2

--- a/definitions/variable/afolu/forestry.yaml
+++ b/definitions/variable/afolu/forestry.yaml
@@ -4,15 +4,15 @@
     unit: million m3/yr
     tier: 1
 - Forestry Demand|Roundwood|{Raw Products}:
-    description: "{Raw Products} demand"
+    description: Demand for {Raw Products}
     unit: million m3/yr
     tier: 2
 - Forestry Demand|Roundwood|Industrial Roundwood|Material Use:
-    description: Industrial roundwood demand - used as material for wood products
+    description: Demand of industrial roundwood to be used as material for wood products
     unit: million m3/yr
     tier: 2
 - Forestry Demand|Roundwood|Industrial Roundwood|Energy Use:
-    description: Industrial roundwood demand - used for energy
+    description: Demand of industrial roundwood for energy use
     unit: million m3/yr
     tier: 2
 
@@ -22,7 +22,7 @@
     unit: million m3/yr
     tier: 1
 - Forestry Production|Roundwood|{Raw Products}:
-    description: "{Raw Products} production"
+    description: Prodution of {Raw Products}
     unit: million m3/yr
     tier: 2
 
@@ -38,15 +38,15 @@
 
 # Forestry Demand, Production and Trade of Semi-Finished Products
 - Forestry Demand|Semi-Finished|{Semi-Finished Products}:
-    description: "{Semi-Finished Products} demand"
+    description: Demand for {Semi-Finished Products}
     unit: "{Semi-Finished Products}"
     tier: 3
 - Forestry Production|Semi-Finished|{Semi-Finished Products}:
-    description: "{Semi-Finished Products} production"
+    description: Production of "{Semi-Finished Products}
     unit: "{Semi-Finished Products}"
     tier: 3
 - Trade|Forestry|Semi-Finished|{Semi-Finished Products}:
-    description: "Net export of {Semi-Finished Products}"
+    description: Net export of {Semi-Finished Products}
     unit: "{Semi-Finished Products}"
     tier: 3
 

--- a/definitions/variable/afolu/forestry.yaml
+++ b/definitions/variable/afolu/forestry.yaml
@@ -8,11 +8,11 @@
     unit: million m3/yr
     tier: 2
 - Forestry Demand|Roundwood|Industrial Roundwood|Material Use:
-    description: Demand of industrial roundwood to be used as material for wood products
+    description: Demand for industrial roundwood to be used as material for wood products
     unit: million m3/yr
     tier: 2
 - Forestry Demand|Roundwood|Industrial Roundwood|Energy Use:
-    description: Demand of industrial roundwood for energy use
+    description: Demand for industrial roundwood for energy use
     unit: million m3/yr
     tier: 2
 

--- a/definitions/variable/afolu/land-cover-change.yaml
+++ b/definitions/variable/afolu/land-cover-change.yaml
@@ -5,75 +5,75 @@
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Deforestation:
-    description: Annual gross deforestation
+    description: Annual gross deforested area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Deforestation|Primary:
-    description: Annual gross loss of primary forest
+    description: Annual gross loss of primary forest area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Deforestation|Secondary:
-    description: Annual gross loss of secondary forest
+    description: Annual gross loss of secondary forest area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion:
-    description: Annual gross forest expansion
+    description: Annual gross expansion of forest area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Secondary:
-    description: Annual gross expansion of secondary forest
+    description: Annual gross expansion of secondary forest area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted:
-    description: Annual gross expansion of planted forest
+    description: Annual gross expansion of planted forest area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Plantation:
-    description: Annual gross expansion of plantations
+    description: Annual gross expansion of plantation area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Plantation|Timber:
-    description: Annual gross expansion of timber plantation
+    description: Annual gross expansion of timber plantation area
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Plantation|Re/Afforestation:
-    description: Annual gross expansion of carbon plantations; Reforestation and/or 
-       Afforestation with monoculture and/or non-native species
+    description: Annual gross expansion of carbon plantation area through reforestation
+      and/or afforestation with monoculture and/or non-native species
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Natural:
-    description: Annual gross expansion of planted forest not classified as plantation forest 
+    description: Annual gross expansion of planted forest area not classified as plantation forest
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Natural|Re/Afforestation:
-    description: Annual gross Reforestation and/or Afforestation for carbon sequestration 
-      with native tree  species
+    description: Annual gross reforestation and/or afforestation area for carbon sequestration
+      with native tree species
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr
     tier: 3
 - Forest Area Change|Forest Expansion|Planted|Natural|Other:
-    description: Annual gross expansion of other planted forest not classified as plantation 
+    description: Annual gross expansion of other planted forest area not classified as plantation
     notes: This variable should be computed as yearly average change between the previous
       and the current reported time step.
     unit: million ha/yr

--- a/definitions/variable/afolu/tag_crop-non-energy.yaml
+++ b/definitions/variable/afolu/tag_crop-non-energy.yaml
@@ -7,5 +7,4 @@
     - Sugar Crops:
         description: sugar crops (sugar beet, sugar cane)
     - Other Crops:
-        description: other crops (fruits, vegetables, nuts, potatoes, pulses,
-          tropical roots)
+        description: other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots)

--- a/definitions/variable/afolu/tag_forestry-raw-products.yaml
+++ b/definitions/variable/afolu/tag_forestry-raw-products.yaml
@@ -1,5 +1,5 @@
 - Raw Products:
     - Industrial Roundwood:
-        description: Industrial Roundwood
+        description: industrial roundwood
     - Wood Fuel:
-        description: Wood fuel
+        description: wood fuel

--- a/definitions/variable/afolu/tag_forestry-semi-finished.yaml
+++ b/definitions/variable/afolu/tag_forestry-semi-finished.yaml
@@ -1,19 +1,19 @@
 - Semi-Finished Products:
     - Sawnwood:
-        description: Sawnwood
+        description: sawnwood
         unit: million m3/yr
     - Plywood:
-        description: Plywood
+        description: plywood
         unit: million m3/yr
     - Fiberboard:
-        description: Fiberboard
+        description: fiberboard
         unit: million m3/yr
     - Other Wood Products:
-        description: Other wood products
+        description: other wood products
         unit: million m3/yr
     - Mechanical Pulp:
-        description: Mechanical pulp
+        description: mechanical pulp
         unit: million tDM/yr
     - Chemical Pulp:
-        description: Chemical pulp
+        description: chemical pulp
         unit: million tDM/yr

--- a/definitions/variable/afolu/water-ecosystems.yaml
+++ b/definitions/variable/afolu/water-ecosystems.yaml
@@ -1,32 +1,32 @@
 - Water Ecosystems:
-    description: All water ecosystems
+    description: Area of all water ecosystems
     unit: million ha
     tier: 2
 - Water Ecosystems|Lakes:
-    description: Lakes
+    description: Area of lakes
     unit: million ha
     tier: 2
 - Water Ecosystems|Rivers:
-    description: Rivers
+    description: Area of rivers
     unit: million ha
     tier: 2
 - Water Ecosystems|Wetlands:
-    description: Wetlands
+    description: Area of wetlands
     unit: million ha
     tier: 2
 - Water Ecosystems|Wetlands|Peatlands:
-    description: Peatlands
+    description: Area of peatlands
     unit: million ha
     tier: 2
 - Water Ecosystems|Wetlands|Peatlands|Intact:
-    description: Intact peatlands
+    description: Area of intact peatlands
     unit: million ha
     tier: 2
 - Water Ecosystems|Wetlands|Peatlands|Drained:
-    description: Drained peatlands
+    description: Area of drained peatlands
     unit: million ha
     tier: 2
 - Water Ecosystems|Wetlands|Peatlands|Rewetted:
-    description: Rewetted peatlands
+    description: Area of rewetted peatlands
     unit: million ha
     tier: 2


### PR DESCRIPTION
After merging #180, I noticed one "wrong" variable name ("Energy crops" instead of all-capitalized words), and I couldn't help myself but also clean up the descriptions of the AFOLU variable names for consistency 