### PR TITLE
Add capacity-additions variables for non-electricity energy

### DIFF
--- a/definitions/variable/energy/secondary-energy-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-electricity.yaml
@@ -11,12 +11,12 @@
 - Capacity|Electricity|{Electricity Source}:
     description: Installed (available) capacity to generate electricity from {Electricity Source}
     unit: GW
-- Capacity Addition|Electricity:
+- Capacity Additions|Electricity:
     description: Total annual new installation of electricity generation capacity
     unit: GW
     notes: This variable should be computed as yearly average additions between the previous
       and the current reported time step.
-- Capacity Addition|Electricity|{Electricity Source}:
+- Capacity Additions|Electricity|{Electricity Source}:
     description: Annual new installation of capacity to generate electricity
       from {Electricity Source}
     unit: GW

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -11,3 +11,9 @@
     description: Installed (available) capacity to produce {Secondary Fuel Level 2} {CCS}
     unit: GW
     tier: "{Secondary Fuel Level 2}"
+- Capacity Additions|{Secondary Fuel Level 2}:
+    description: Total annual new capacity installation to produce {Secondary Fuel Level 2}
+    unit: GW
+    tier: "{Secondary Fuel Level 2}"
+    notes: This variable should be computed as yearly average additions between the previous
+      and the current reported time step.


### PR DESCRIPTION
This PR adds investment variables suggested by @gunnar-pik for capacity and capacity additions of non-electricity energy-carriers. And fixing a typo introduced in #177.

FYI @IAMconsortium/common-definitions-energy 