### PR TITLE
Harmonize Russia in G20-list with `nomenclature.countries`

### DIFF
--- a/definitions/region/g20.yaml
+++ b/definitions/region/g20.yaml
@@ -12,7 +12,7 @@
     - Italy
     - Japan
     - Mexico
-    - Russia
+    - Russian Federation
     - Saudi Arabia
     - South Africa
     - South Korea

--- a/mappings/COFFEE_1.5.yaml
+++ b/mappings/COFFEE_1.5.yaml
@@ -142,8 +142,7 @@ common_regions:
       - KR
   - South Africa:
       - SF
-  - Russia:
+  - Russian Federation:
       - RU
   - United States:
       - US
-


### PR DESCRIPTION
This PR fixes an error in the list of the G20-countries identified by @korsbakken in #203 and harmonizes the region-name with the `nomenclature.countries` convention.

