### PR TITLE
Quickfix for production prices

### DIFF
--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -19,5 +19,5 @@
     unit: USD_2010/Mt
     tier: "{Chemicals Commodity}"
     weight: Production|Chemicals|{Chemicals Commodity}
-    navigate: Price|Industry|{Chemicals Commodity}
-    engage: Price|Industry|{Chemicals Commodity}
+    navigate: Price|Industry|Chemicals|{Chemicals Commodity}
+    engage: Price|Industry|Chemicals|{Chemicals Commodity}

--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -6,6 +6,14 @@
     navigate: Price|Industry|Iron and Steel|{Iron Commodity}
     engage: Price|Industry|Iron and Steel|{Iron Commodity}
 
+- Price|Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}:
+    description: Price of {Non-Metallic Minerals Commodity}
+    unit: USD_2010/Mt
+    tier: "{Non-Metallic Minerals Commodity}"
+    weight: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
+    navigate: Price|Industry|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
+    engage: Price|Industry|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
+
 - Price|Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
     description: Price of {Non-Ferrous Metals Commodity}
     unit: USD_2010/Mt


### PR DESCRIPTION
This PR adds variables for industrial prices of non-metallic minerals and fixes an incorrect mapping to legacy variables.