### PR TITLE
Add variables for carbon capture by source

### DIFF
--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -27,6 +27,18 @@
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
+- Carbon Capture|Direct Air Capture:
+    description: Captured carbon dioxide (CO2) from direct air capture
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Other:
+    description: Captured carbon dioxide (CO2) from other sources
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
 
 - Carbon Capture|Geological Storage:
     description: Captured carbon dioxide (CO2) that is injected into subsurface geologic

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -33,6 +33,12 @@
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
+- Carbon Capture|Direct Ocean Capture:
+    description: Captured carbon dioxide (CO2) from direct ocean capture
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
 - Carbon Capture|Other:
     description: Captured carbon dioxide (CO2) from other sources
     unit: Mt CO2/yr

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -1,10 +1,7 @@
 - Carbon Capture:
-    description: Total amount of captured carbon dioxide (CO2) from energy use in supply
-      and demand sectors (IPCC category 1A, 1B) and from industrial processes
-      (IPCC categories 2A, B, C, E), including emissions from international bunkers,
-      net of negative emissions from bioenergy with CCS (BECCS),
-      direct air carbon capture and storage (DACCS), and other CO2 removal exclusive of
-      land-use change in these sectors
+    description: Total amount of carbon dioxide (CO2) captured either from the atmosphere,
+      directly from oceans, or from point sources as energy use in supply and demand
+      sectors (IPCC category 1A, 1B) or industrial processes (IPCC categories 2A, B, C, E)
     unit: Mt CO2/yr
     tier: 1
     lower_bound: 0

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -1,5 +1,3 @@
-# Carbon Capture is grouped into two levels of aggregation based on the fate of the captured CO2
-# storage versus utilization
 - Carbon Capture:
     description: Total amount of captured carbon dioxide (CO2) from energy use in supply
       and demand sectors (IPCC category 1A, 1B) and from industrial processes
@@ -8,6 +6,14 @@
       direct air carbon capture and storage (DACCS), and other CO2 removal exclusive of
       land-use change in these sectors
     unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    components:
+      - Carbon Capture|Geological Storage
+      - Carbon Capture|Other Storage
+      - Carbon Capture|Leakage
+      - Carbon Capture|Utilization
+
 - Carbon Capture|{Carbon Capture Source}:
     description: Captured carbon dioxide (CO2) from {Carbon Capture Source}
     unit: Mt CO2/yr
@@ -26,21 +32,31 @@
     description: Captured carbon dioxide (CO2) that is injected into subsurface geologic
       storage reservoirs (e.g., in situ mineralization).
     unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
     notes: Captured CO2 that is reacted at the earth's surface (e.g., ex situ mineralization)
       should be reported under Carbon Capture|Other Storage
 - Carbon Capture|Other Storage:
     description: Other types of storage for captured carbon dioxide (CO2)
     unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
 - Carbon Capture|Leakage:
     description: Captured carbon dioxide (CO2) that is vented, leaked, or re-emitted
       during transport or after injection into storage
     unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
     notes: Leakage should be reported as positive values. Leakage of CO2 stored in
       previous years should be reported here.
 - Carbon Capture|Utilization:
     description: Captured carbon dioxide (CO2) that is used in the manufacture of fuels
       or materials, or to enhance the productivity of oil and/or natural gas reservoirs
     unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
 - Carbon Capture|Utilization|{Carbon Utilization Type}:
     description: Captured carbon dioxide (CO2) that is used to produce {Carbon Utilization Type}
     unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -8,6 +8,20 @@
       direct air carbon capture and storage (DACCS), and other CO2 removal exclusive of
       land-use change in these sectors
     unit: Mt CO2/yr
+- Carbon Capture|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) from {Carbon Capture Source}
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Industrial Processes:
+    description: Captured carbon dioxide (CO2) from industrial processes
+      (e.g., cement production), not including energy use
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+
 - Carbon Capture|Geological Storage:
     description: Captured carbon dioxide (CO2) that is injected into subsurface geologic
       storage reservoirs (e.g., in situ mineralization).

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -58,7 +58,7 @@
     lower_bound: 0
 - Carbon Capture|Leakage:
     description: Captured carbon dioxide (CO2) that is vented, leaked, or re-emitted
-      during transport or after injection into storage
+      during transport
     unit: Mt CO2/yr
     tier: 1
     lower_bound: 0

--- a/definitions/variable/emissions/tag_carbon-capture-source.yaml
+++ b/definitions/variable/emissions/tag_carbon-capture-source.yaml
@@ -5,5 +5,17 @@
     - Fossil:
         description: fossil fuels including coal, natural gas and conventional/unconventional oil
     - Synthetic Fuels:
-        description: synthetic fuels produced from carbon-capture-and-utilization (CCU),
-          not derived from fossil fuels
+        description: synthetic fuels produced from carbon captured from fossil fuels and
+          directly or indirectly from the atmosphere,
+          e.g. using carbon-capture-and-utilization (CCU) from biomass or fossil fuels
+          or Direct Air Capture (DAC)
+    - Synthetic Fuels|Carbon-Neutral:
+        description: synthetic fuels produced from carbon captured directly or indirectly
+          from the atmosphere, e.g. using carbon-capture-and-utilization (CCU) from biomass
+          or Direct Air Capture (DAC), not derived from fossil fuels
+    - Synthetic Fuels|Fossil-Based:
+        description: synthetic fuels produced from carbon-capture-and-utilization (CCU)
+          of fossil fuels
+    - Synthetic Fuels|Industrial Processes:
+        description: synthetic fuels produced from carbon-capture-and-utilization (CCU)
+          of industrial processes

--- a/definitions/variable/emissions/tag_carbon-capture-source.yaml
+++ b/definitions/variable/emissions/tag_carbon-capture-source.yaml
@@ -1,0 +1,9 @@
+- Carbon Capture Source:
+    - Biomass:
+        description: purpose-grown bioenergy crops, biogas, crop and forestry residue,
+          municipal solid waste bioenergy and traditional biomass
+    - Fossil:
+        description: fossil fuels including coal, natural gas and conventional/unconventional oil
+    - Synthetic Fuels:
+        description: synthetic fuels produced from carbon-capture-and-utilization (CCU),
+          not derived from fossil fuels

--- a/definitions/variable/emissions/tag_carbon-capture-source.yaml
+++ b/definitions/variable/emissions/tag_carbon-capture-source.yaml
@@ -13,7 +13,7 @@
         description: synthetic fuels produced from carbon captured directly or indirectly
           from the atmosphere, e.g. using carbon-capture-and-utilization (CCU) from biomass
           or Direct Air Capture (DAC), not derived from fossil fuels
-    - Synthetic Fuels|Fossil-Based:
+    - Synthetic Fuels|Fossil:
         description: synthetic fuels produced from carbon-capture-and-utilization (CCU)
           of fossil fuels
     - Synthetic Fuels|Industrial Processes:

--- a/definitions/variable/emissions/tag_geological-storage.yaml
+++ b/definitions/variable/emissions/tag_geological-storage.yaml
@@ -1,5 +1,5 @@
 - Geogological Storage Source:
-    - Bioenergy:
+    - Biomass:
         description: geological storage of CO2 from biogenic orgin, i.e.,
           bioenergy with carbon capture and storage (BECCS)
     - Direct Air Capture:


### PR DESCRIPTION
This PR implements changes discussed by email among the emissions-group (see in particular the email by @strefler on October 10).

The changes in particular:
- add variables for carbon capture by source (fossil, biomass, synthetic, processes)
- add tiers and bounds for existing carbon-capture variables
- add the list of components of the top-level "Carbon Capture" variable to clarify that "Carbon Capture|Fossil" and "Carbon Capture|Geological Storage" should not be added up


[EDIT by @gidden]: The October 10 email includes the following attachment [MissingVariables-CDR-CCS.xlsx](https://github.com/user-attachments/files/17747560/MissingVariables-CDR-CCS.xlsx)

[EDIT by @gidden]:

We propose 3 main variable elements:

1. the "reservoir tree" denoting the provenance of carbon in each storage reservoir (`Carbon Capture|<Storage Reservoir>|<Carbon Source>`)
2. the "full tree" denoting in which sectors carbon is captured, the type of carbon captured, and the final resting place of that carbon (`Carbon Capture|<Sector>|<Carbon source>|<Storage Reservoir>` )
3.  the "source tree" denoting at a high level source totals (`Carbon Capture|<Carbon source>`)

Reservoirs include:
- Geologic storage
- Other storage
- Leakage and other Losses
- Utilization

Sources include:
- Biomass (or biogenic)
- Fossil
- Synthetic Fuel
- Direct Air Capture
- Direct Ocean Capture
- Industrial Processes
- Other Sources

Sectors include all relevant sectors from Energy, Industry, etc.

Key overlaps with Carbon Removal:

- Carbon Removal|Geologic Storage will be strictly less or equal to Carbon Capture|Geologic Storage (as it does not include fossil sources)
- Carbon Removal|Geological Storage|Bioenergy, Carbon Removal|Geological Storage|Direct Air Capture, and Carbon Removal|Geological Storage|Synthetic Fuels will have 1-to-1 analogues with the Carbon Capture reservoir tree
- Carbon Removal|Long-Lived Materials will equal the sum of non-fossil contributions to Carbon Capture|Utilization

Key other considerations
- Carbon capture only refers to energy and industrial processes, not, e.g., Forestry
- We will not include in the Capture tree silicate, weathering, and ocean-based methods




