### PR TITLE
Add variables for combustion and fugitive emissions of fuel supply

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -253,12 +253,12 @@
 - Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 1}|Combustion:
     description: Emissions of {Level-2 Species} from fuel combustion during production
       of {Secondary Fuel Level 1}
-    unit: "{Level-1 Species}"
+    unit: "{Level-2 Species}"
     tier: 2
 - Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 1}|Fugitive:
     description: Fugitive emissions of {Level-2 Species} during production
       of {Secondary Fuel Level 1}
-    unit: "{Level-1 Species}"
+    unit: "{Level-2 Species}"
     tier: 2
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -231,12 +231,12 @@
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei) and
       emissions from carbon dioxide transport and storage (IPCC category 1C)
     unit: "{Level-2 Species}"
-    tier: 2
+    tier: 3
 - Emissions|{Level-2 Species}|Energy|Supply|Fugitive:
     description: Fugitive emissions of {Level-2 Species} from fuels in energy extraction,
       processing, storage and transport (IPCC category 1B)
     unit: "{Level-2 Species}"
-    tier: 2
+    tier: 3
 - Emissions|{Level-2 Species}|Energy|Supply|Electricity:
     description: Emissions of {Level-2 Species} for electricity generation
     unit: "{Level-2 Species}"
@@ -254,12 +254,12 @@
     description: Emissions of {Level-2 Species} from fuel combustion during production
       of {Secondary Fuel Level 1}
     unit: "{Level-2 Species}"
-    tier: 2
+    tier: 3
 - Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 1}|Fugitive:
     description: Fugitive emissions of {Level-2 Species} during production
       of {Secondary Fuel Level 1}
     unit: "{Level-2 Species}"
-    tier: 2
+    tier: 3
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},
       not accounting for removals from the atmosphere

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -250,6 +250,16 @@
     description: Emissions of {Level-2 Species} for production of {Secondary Fuel Level 2}
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 1}|Combustion:
+    description: Emissions of {Level-2 Species} from fuel combustion during production
+      of {Secondary Fuel Level 1}
+    unit: "{Level-1 Species}"
+    tier: 2
+- Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 1}|Fugitive:
+    description: Fugitive emissions of {Level-2 Species} during production
+      of {Secondary Fuel Level 1}
+    unit: "{Level-1 Species}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},
       not accounting for removals from the atmosphere


### PR DESCRIPTION
This PR adds variables to distinguish between fugitive and combustion emissions at the energy-supply-by-fuel resolution, based on a discussion between @volker-krey and Steve Smith related to CEDS and CMIP6 harmonization.

Note that "Emissions|{Level-2 Species}|Energy|Supply|Combustion" and "Emissions|{Level-2 Species}|Energy|Supply|Fugitive" are already included in the template.