### PR TITLE
Add validation-criteria from AR6 WG3 Annex 3 Table 11

### DIFF
--- a/validate_data/ar6-criteria-2020.yaml
+++ b/validate_data/ar6-criteria-2020.yaml
@@ -1,0 +1,39 @@
+# Validation criteria from IPCC AR6 WG3
+# Annex III: "Scenarios and Modelling Methods", Table 11, Page 1883
+# https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Annex-III.pdf
+
+# This implementation applies the narrower ranges as used for the IMP vetting
+
+# Historical emissions (sources: EDGAR V6 IPCC and CEDS, 2019 values
+- region: World
+  variable: Emissions|CO2
+  year: 2020
+  value: 44251  # unit Mt CO2/yr
+  rtol: 0.20
+- region: World
+  variable: Emissions|CO2|Energy and Industrial Processes
+  year: 2020
+  value: 37646  # Mt CO2/yr
+  rtol: 0.10
+- region: World
+  variable: Emissions|CH4
+  year: 2020
+  value: 379  # Mt CH4/yr
+  rtol: 0.20
+- region: World
+  variable: Carbon Capture
+  year: 2020
+  upper_bound: 100  # Mt CO2/yr
+  lower_bound: 0  # Mt CO2/yr
+
+# Historical energy production (sources: IEA 2019; IRENA; BP; EMBERS)
+- region: World
+  variable: Primary Energy
+  year: 2020
+  value: 578  # EJ/yr
+  rtol: 0.10
+- region: World
+  variable: Secondary Energy|Electricity|Nuclear
+  year: 2020
+  value: 9.77  # EJ/yr
+  rtol: 0.20


### PR DESCRIPTION
This PR adds the validation-criteria from AR6 WG3 Annex 3 Table 11 for emissions and energy-production in 2020.

Table 11 also has a row on combined solar and wind generation (8.51 EJ in 2020), which I have not included because there is no standard variable for "solar plus wind" in common-definitions.

@byersiiasa, is there a reason why you combined solar and wind, and do you have the disaggregated reference values so that we could use that for more fine-grained validation criteria?

FYI @IAMconsortium/common-definitions-coordination @IAMconsortium/common-definitions-emissions @IAMconsortium/common-definitions-energy 