### PR TITLE
Implement proper tiers for final-energy variables

### DIFF
--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -169,6 +169,10 @@
     navigate: Final Energy|Bunkers|{Transportation Sector}|{Bunker Sector}
 
 # additional variables for the water sector
+- Final Energy|Commercial|Water:
+    description: Energy consumption for water desalination, extraction, and transfer
+    unit: EJ/yr
+    tier: 2
 - Final Energy|Commercial|Water|Desalination:
     description: Energy consumption for water desalination
     unit: EJ/yr

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -3,131 +3,156 @@
     description: Final energy consumption by all end-use sectors and all fuels,
       including non-energy use, excluding transmission/distribution losses
     unit: EJ/yr
+    tier: 1
 - Final Energy (w/o bunkers):
     description: Final energy consumption by all end-use sectors and all fuels
       including non-energy use, excluding international aviation and shipping (see "Bunkers"),
       excluding transmission/distribution losses
     unit: EJ/yr
+    tier: 2
 
 # Non-energy use
 - Final Energy|Non-Energy Use:
     description: Final energy consumption in non-combustion processes
     unit: EJ/yr
+    tier: 2
 - Final Energy|Non-Energy Use|{Secondary Fuel Level 2}:
     description: Final energy consumption of {Secondary Fuel Level 2} in non-combustion processes
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Final Energy|Non-Energy Use|Waste:
     description: Final energy consumption of non-renewable waste in non-combustion processes
     unit: EJ/yr
+    tier: 2
 - Final Energy|Non-Energy Use|{Non-Energy Sector}:
     description: Final energy consumption by the {Non-Energy Sector} for non-combustion processes
     unit: EJ/yr
+    tier: 2
 - Final Energy|Non-Energy Use|{Non-Energy Sector}|{Secondary Fuel Level 2}:
     description: Final energy consumption of {Secondary Fuel Level 2} by the {Non-Energy Sector}
       for non-combustion processes
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Final Energy|Non-Energy Use|{Non-Energy Sector}|Waste:
     description: Final energy consumption of non-renewable waste by the {Non-Energy Sector}
       for non-combustion processes
     unit: EJ/yr
+    tier: 2
 - Final Energy|Non-Energy Use|{Non-Energy Sector}|Other:
     description: Final energy consumption of other feedstocks by the {Non-Energy Sector}
       for non-combustion processes
     unit: EJ/yr
+    tier: 3
 - Final Energy|Non-Energy Use|Other:
     description: Final energy consumption of other feedstocks in non-combustion processes
     unit: EJ/yr
+    tier: 2
 
 # Final energy by fuel
 - Final Energy|Electricity:
     description: Final energy consumption of electricity (including on-site solar PV),
       excluding transmission/distribution losses
     unit: EJ/yr
+    tier: 1
 - Final Energy|{Secondary Fuel Level 2}:
     description: Final energy fuel consumption of {Secondary Fuel Level 2}
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 1
 - Final Energy|Geothermal:
     description: Final energy consumption of geothermal energy (e.g., from decentralized
       or small-scale geothermal heating systems) excluding geothermal heat pumps
     unit: EJ/yr
+    tier: 1
 - Final Energy|Waste:
     description: Final energy consumption of non-renewable waste
     unit: EJ/yr
+    tier: 1
 - Final Energy|Solar:
     description: Final energy consumption of solar-thermal heat
       (e.g., from roof-top solar hot water collector systems)
     unit: EJ/yr
+    tier: 1
 - Final Energy|Other:
     description: Final energy consumption of other energy sources
     unit: EJ/yr
+    tier: 2
 
 # Final energy by sector and fuel
 - Final Energy|{Sector}:
     description: Final energy consumption by the {Sector}
     unit: EJ/yr
+    tier: 1
 - Final Energy|{Sector}|Electricity:
     description: Final energy consumption by the {Sector} of electricity
     unit: EJ/yr
+    tier: 1
 - Final Energy|{Sector}|{Secondary Fuel Level 2}:
     description: Final energy consumption by the {Sector} of {Secondary Fuel Level 2}
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 1
 - Final Energy|{Sector}|Other:
     description: Final energy consumption by the {Sector} of other energy sources
     unit: EJ/yr
+    tier: 2
 
 # additional combinations of sector and energy-carriers not included in {Sector} x {Secondary Fuel}
 - Final Energy|Industry|Geothermal:
     description: Final energy consumption by the industrial sector of geothermal heat
     unit: EJ/yr
+    tier: 2
 - Final Energy|Industry|Solar:
     description: Final energy consumption by the industrial sector of solar thermal heat
     unit: EJ/yr
+    tier: 2
 - Final Energy|Industry|Waste:
     description: Final energy consumption of non-renewable waste by the industrial sector
     unit: EJ/yr
+    tier: 2
 
 # energy use for carbon capture and/or removal technologies
 - Final Energy|Carbon Management:
     description: Total energy use for carbon management, i.e., capture and/or removal of CO2
     unit: EJ/yr
+    tier: 2
     navigate: Final Energy|Carbon Removal
 - Final Energy|Carbon Management|Electricity:
     description: Electricity use for carbon management
     unit: EJ/yr
+    tier: 2
     notes: See `Secondary Energy|Electricity|...` for the power generation mix
     navigate: Final Energy|Carbon Removal|Electricity
 - Final Energy|Carbon Management|{Secondary Fuel Level 2}:
     description: Use of {Secondary Fuel Level 2} for carbon management
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
     navigate: Final Energy|Carbon Removal|{Secondary Fuel Level 2}
 - Final Energy|Carbon Management|Other:
     description: Use of other energy sources for carbon management
     unit: EJ/yr
+    tier: 2
 # the list of carbon management technologies is given in
 # definitions/variable/emissions/tag_carbon-management.yaml
 - Final Energy|Carbon Management|{Carbon Management Technology}:
     description: Energy use for carbon management by {Carbon Management Technology}
     unit: EJ/yr
+    tier: 2
 - Final Energy|Carbon Management|{Carbon Management Technology}|Electricity:
     description: Electricity use for carbon management by {Carbon Management Technology}
     unit: EJ/yr
+    tier: 2
     notes: See `Secondary Energy|Electricity|...` for the power generation mix
     navigate: Final Energy|Carbon Removal|Electricity|{Carbon Management Technology}
     engage: Final Energy|Carbon Removal|Electricity|{Carbon Management Technology}
 - Final Energy|Carbon Management|{Carbon Management Technology}|{Secondary Fuel Level 2}:
     description: Use of {Secondary Fuel Level 2} for carbon management by {Carbon Management Technology}
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
     navigate: Final Energy|Carbon Removal|{Secondary Fuel Level 2}|{Carbon Management Technology}
     engage: Final Energy|Carbon Removal|{Secondary Fuel Level 2}|{Carbon Management Technology}
 - Final Energy|Carbon Management|{Carbon Management Technology}|Other:
     description: Use of other energy sources for carbon removal by {Carbon Management Technology}
     unit: EJ/yr
+    tier: 2
 
 # additional variable for international aviation and shipping ("Bunkers")
 - Final Energy|Bunkers|{Bunker Sector}:

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -158,13 +158,16 @@
 - Final Energy|Bunkers|{Bunker Sector}:
     description: Final energy consumption for {Bunker Sector}
     unit: EJ/yr
+    tier: 1
 - Final Energy|Bunkers|{Transportation Sector}:
     description: Final energy consumption for {Transportation Sector}
       in international aviation and shipping
     unit: EJ/yr
+    tier: 2
 - Final Energy|Bunkers|{Bunker Sector}|{Transportation Sector}:
     description: Final energy consumption for {Transportation Sector} in {Bunker Sector}
     unit: EJ/yr
+    tier: 2
     engage: Final Energy|Bunkers|{Transportation Sector}|{Bunker Sector}
     navigate: Final Energy|Bunkers|{Transportation Sector}|{Bunker Sector}
 
@@ -176,12 +179,16 @@
 - Final Energy|Commercial|Water|Desalination:
     description: Energy consumption for water desalination
     unit: EJ/yr
+    tier: 3
 - Final Energy|Commercial|Water|Groundwater Extraction:
     description: Energy consumption for groundwater extraction
     unit: EJ/yr
+    tier: 3
 - Final Energy|Commercial|Water|Surface Water Extraction:
     description: Energy consumption for surface water extraction
     unit: EJ/yr
+    tier: 3
 - Final Energy|Commercial|Water|Transfer:
     description: Energy consumption for water transfers
     unit: EJ/yr
+    tier: 3

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -5,29 +5,41 @@
         description: industrial sector excluding non-energy use (e.g.feedstocks)
     - Industry|Iron and Steel:
         description: iron and steel sector excluding feedstocks
+        tier: ^1
     - Industry|Non-Ferrous Metals:
         description: non-ferrous metals sector
+        tier: ^1
     - Industry|Non-Metallic Minerals:
         description: non-metallic minerals sector excluding cement
+        tier: ^1
     - Industry|Chemicals:
         description: chemicals sector excluding feedstocks
+        tier: ^1
     # keep consistent with the sub-categories of `Chemicals` in the `Industrial-Process Sector` tag list
     - Industry|Chemicals|Ammonia:
         description: ammonia sector
+        tier: ^2
     - Industry|Chemicals|Methanol:
         description: methanol sector
+        tier: ^2
     - Industry|Chemicals|High-Value Chemicals:
         description: high-value-chemicals sector
+        tier: ^2
     - Industry|Chemicals|Other Sector:
         description: other use in the chemical sector
+        tier: ^2
     - Industry|Cement:
         description: cement sector
+        tier: ^1
     - Industry|Plastics:
         description: plastics sector
+        tier: ^1
     - Industry|Pulp and Paper:
         description: pulp and paper
+        tier: ^1
     - Industry|Other Sector:
         description: other industrial sectors
+        tier: ^1
     - Residential:
         description: residential sector
     - Commercial:
@@ -41,22 +53,31 @@
         description: transportation sector including international aviation and shipping
     - Transportation|Bus:
         description: transportation sector by bus
+        tier: ^1
     - Transportation|Light Duty Vehicle:
         description: transportation sector with light-duty vehicles
+        tier: ^1
     - Transportation|Truck:
         description: trucking sector
+        tier: ^1
     - Transportation|Rail:
         description: rail transportation sector
+        tier: ^1
     - Transportation|Domestic Aviation:
         description: domestic aviation sector
+        tier: ^1
     - Transportation|Domestic Shipping:
         description: domestic shipping sector
+        tier: ^1
     - Transportation|Passenger:
         description: passenger transportation sector excluding international aviation
           and shipping
+        tier: ^1
     - Transportation|Freight:
         description: freight transportation sector excluding international aviation and shipping
+        tier: ^1
     - Bunkers:
         description: international aviation and shipping
     - Other Sector:
         description: other sectors
+        tier: ^1

--- a/definitions/variable/energy/tag_non_energy_sectors.yaml
+++ b/definitions/variable/energy/tag_non_energy_sectors.yaml
@@ -13,13 +13,18 @@
     # keep consistent with the sub-categories of `Industry|Chemicals` in the `Sector` tag list
     - Chemicals|Ammonia:
         description: ammonia sector
+        tier: ^1
     - Chemicals|Methanol:
         description: methanol sector
+        tier: ^1
     - Chemicals|High-Value Chemicals:
         description: high-value-chemicals sector
+        tier: ^1
     - Chemicals|Other Sector:
         description: other use in the chemical sector
+        tier: ^1
     - Plastics:
         description: plastics sector
     - Other Sector:
         description: other industries
+        tier: ^1

--- a/definitions/variable/energy/tag_secondary_energy_carriers_level-2.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_level-2.yaml
@@ -6,141 +6,136 @@
     - Liquids:
         description: refined liquid fuels including oil products, fuels from gas and coal,
           synthetic fuels and biofuels
-        tier: "1"
     - Liquids|Biomass:
         description: liquid fuels from biomass
-        tier: "2"
+        tier: ^1
     - Liquids|Fossil:
         description: liquid fuels from fossil fuels including coal, natural gas and
           conventional/unconventional oil
-        tier: "2"
+        tier: ^1
     - Liquids|Oil:
         description: liquid fuels from refined crude oil
-        tier: "2"
+        tier: ^1
     - Liquids|Coal:
         description: liquid fuels from coal
-        tier: "2"
+        tier: ^1
     - Liquids|Gas:
         description: liquid fuels from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Liquids|Hydrogen:
         description: liquid fuels from hydrogen (if hydrogen is explicitly modeled as a
           commodity and not an implicit intermediate product of the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Liquids|Electricity:
         description: liquid synthetic fuels from electricity, i.e., e-fuels (if hydrogen
           is not explicitly modeled as an intermediate product)
-        tier: "2"
+        tier: ^1
     - Liquids|Other:
         description: sources that do not fit any other category
-        tier: "2"
+        tier: ^1
 
     - Solids:
         description: solid energy carriers, including coal, briquettes, coke,
           and wood pellets
-        tier: "1"
     - Solids|Biomass:
         description: solid biomass (e.g., commercial charcoal, wood chips, wood pellets),
           not including traditional bioenergy
-        tier: "2"
+        tier: ^1
     - Solids|Coal:
         description: coal, lignite, and derived products (e.g., coke, briquettes)
-        tier: "2"
+        tier: ^1
 
     - Gases:
         description: gaseous fuels including natural gas and biogas, not including hydrogen
-        tier: "1"
     - Gases|Biomass:
         description: gaseous fuels from biogenic sources, mainly biogas
-        tier: "2"
+        tier: ^1
     - Gases|Fossil:
         description: gaseous fuels from fossil fuels including natural gas and coal
-        tier: "2"
+        tier: ^1
     - Gases|Coal:
         description: gaseous fuels from fossil coal gasification
-        tier: "2"
+        tier: ^1
     - Gases|Gas:
         description: fossil methane ("natural gas")
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen:
         description: gaseous fuels from hydrogen (if hydrogen is explicitly modeled as a
           commodity and not an implicit intermediate product of the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Electricity:
         description: gas from electricity i.e., 'power-to-gas' (if hydrogen is not
           explicitly modeled as an intermediate product)
-        tier: "2"
+        tier: ^1
     - Gases|Other:
         description: gaseous fuels from sources that do not fit any other category
-        tier: "2"
+        tier: ^1
 
     - Hydrogen:
         description: hydrogen
-        tier: "1"
     - Hydrogen|Biomass:
         description: hydrogen generated from biomass
-        tier: "2"
+        tier: ^1
     - Hydrogen|Fossil:
         description: hydrogen from fossil fuels including natural gas, oil and coal
-        tier: "2"
+        tier: ^1
     - Hydrogen|Oil:
         description: hydrogen from refined crude oil
-        tier: "2"
+        tier: ^1
     - Hydrogen|Coal:
         description: hydrogen from coal
-        tier: "2"
+        tier: ^1
     - Hydrogen|Gas:
         description: hydrogen from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Hydrogen|Electricity:
         description: hydrogen from electrolysis
-        tier: "2"
+        tier: ^1
     - Hydrogen|Nuclear:
         description: hydrogen from nuclear energy
           (e.g. thermochemical water splitting with nuclear heat)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Solar:
         description: hydrogen from solar energy
           (e.g. thermochemical water splitting with solar heat)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Other:
         description: hydrogen from other sources
-        tier: "2"
+        tier: ^1
 
     - Heat:
         description: centralized heat
-        tier: "1"
     - Heat|Biomass:
         description: centralized heat from biomass, including biogas
-        tier: "2"
+        tier: ^1
     - Heat|Fossil:
         description: centralized heat from fossil fuels including natural gas, oil and coal
-        tier: "2"
+        tier: ^1
     - Heat|Oil:
         description: centralized heat from refined crude oil
-        tier: "2"
+        tier: ^1
     - Heat|Coal:
         description: centralized heat from coal
-        tier: "2"
+        tier: ^1
     - Heat|Gas:
         description: centralized heat from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Heat|Hydrogen:
         description: centralized heat from hydrogen
-        tier: "2"
+        tier: ^1
     - Heat|Geothermal:
         description: centralized heat from geothermal energy excluding ground-source heat pumps
-        tier: "2"
+        tier: ^1
     - Heat|Electricity:
         description: centralized heat from electricity
-        tier: "2"
+        tier: ^1
     - Heat|Nuclear:
         description: centralized heat from nuclear energy
-        tier: "2"
+        tier: ^1
     - Heat|Solar:
         description: centralized heat from solar energy
-        tier: "2"
+        tier: ^1
     - Heat|Other:
         description: centralized heat from sources that do not fit any other category
-        tier: "2"
+        tier: ^1
 

--- a/definitions/variable/energy/tag_secondary_energy_carriers_level-3.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_level-3.yaml
@@ -6,275 +6,270 @@
     - Liquids:
         description: refined liquid fuels including oil products, fuels from gas and coal,
           synthetic fuels and biofuels
-        tier: "1"
     - Liquids|Biomass:
         description: liquid fuels from biomass
-        tier: "2"
+        tier: ^1
     - Liquids|Fossil:
         description: liquid fuels from fossil fuels including coal, natural gas and
           conventional/unconventional oil
-        tier: "2"
+        tier: ^1
     - Liquids|Oil:
         description: liquid fuels from refined crude oil
-        tier: "2"
+        tier: ^1
     - Liquids|Coal:
         description: liquid fuels from coal
-        tier: "2"
+        tier: ^1
     - Liquids|Gas:
         description: liquid fuels from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Liquids|Hydrogen:
         description: liquid fuels from hydrogen (if hydrogen is explicitly modeled as a
           commodity and not an implicit intermediate product of the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Liquids|Hydrogen|Fossil:
         description: liquid fuels using hydrogen from fossils (if hydrogen is explicitly
           modeled as a commodity and not an implicit intermediate product of the
           transformation technologies)
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Liquids|Hydrogen|Biomass:
         description: liquid fuels using hydrogen generated from biomass (if hydrogen is
           explicitly modeled as a commodity and not an implicit intermediate product of
           the transformation technologies)
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Liquids|Hydrogen|Electricity:
         description: liquid fuels using hydrogen from electrolysis, i.e., e-fuels (if
           hydrogen is explicitly modeled as a commodity and not an implicit intermediate
           product of the transformation technologies)
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Liquids|Hydrogen|Other:
         description: liquid fuels using hydrogen from other sources (if hydrogen is
           explicitly modeled as a commodity and not an implicit intermediate product of
           the transformation technologies)
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Liquids|Electricity:
         description: liquid synthetic fuels from electricity, i.e., e-fuels (if hydrogen
           is not explicitly modeled as an intermediate product)
-        tier: "2"
+        tier: ^1
     - Liquids|Other:
         description: sources that do not fit any other category
-        tier: "2"
+        tier: ^1
 
     - Solids:
         description: solid energy carriers, including coal, briquettes, coke,
           and wood pellets
-        tier: "1"
     - Solids|Biomass:
         description: solid biomass (e.g., commercial charcoal, wood chips, wood pellets),
           not including traditional bioenergy
-        tier: "2"
+        tier: ^1
     - Solids|Coal:
         description: coal, lignite, and derived products (e.g., coke, briquettes)
-        tier: "2"
+        tier: ^1
 
     - Gases:
         description: gaseous fuels including natural gas and biogas, not including hydrogen
-        tier: "1"
     - Gases|Biomass:
         description: gas from biogenic sources, mainly biogas
-        tier: "2"
+        tier: ^1
     - Gases|Fossil:
         description: gaseous fuels from fossil fuels including natural gas and coal
-        tier: "2"
+        tier: ^1
     - Gases|Coal:
         description: gaseous fuels from coal gasification
-        tier: "2"
+        tier: ^1
     - Gases|Gas:
         description: fossil methane ("natural gas")
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen:
         description: gaseous fuels from hydrogen (if hydrogen is explicitly modeled as a
           commodity and not an implicit intermediate product of the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen|Fossil:
         description: gaseous fuels using hydrogen from fossils (if hydrogen is explicitly
           modeled as a commodity and not an implicit intermediate product of the
           transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen|Biomass:
         description: gaseous fuels using hydrogen generated from biomass (if hydrogen is
           explicitly modeled as a commodity and not an implicit intermediate product of
           the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen|Electricity:
         description: gaseous fuels using hydrogen from electrolysis, i.e., e-fuels
           (if hydrogen is explicitly modeled as a commodity and not an implicit
           intermediate product of the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Hydrogen|Other:
         description: gaseous fuels using hydrogen from other sources (if hydrogen is
           explicitly modeled as a commodity and not an implicit intermediate product of
           the transformation technologies)
-        tier: "2"
+        tier: ^1
     - Gases|Electricity:
         description: gas from electricity i.e., 'power-to-gas' (if hydrogen is not
           explicitly modeled as an intermediate product)
-        tier: "2"
+        tier: ^1
     - Gases|Other:
         description: gaseous fuels from sources that do not fit any other category
-        tier: "2"
+        tier: ^1
 
     - Hydrogen:
         description: hydrogen
-        tier: "1"
     - Hydrogen|Biomass:
         description: hydrogen generated from biomass
-        tier: "2"
+        tier: ^1
     - Hydrogen|Biomass|w/ CCS:
         description: hydrogen generated from biomass in combination with carbon capture
           and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Biomass|w/o CCS:
         description: hydrogen generated from biomass without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Fossil:
         description: hydrogen from fossil fuels including natural gas, oil and coal
-        tier: "2"
+        tier: ^1
     - Hydrogen|Fossil|w/ CCS:
         description: hydrogen from fossil fuels including natural gas, oil and coal in
           combination with carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Fossil|w/o CCS:
         description: hydrogen from fossil fuels including natural gas, oil and coal
           without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Oil:
         description: hydrogen from refined crude oil
-        tier: "2"
+        tier: ^1
     - Hydrogen|Oil|w/ CCS:
         description: hydrogen from refined crude oil in combination with carbon capture
           and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Oil|w/o CCS:
         description: hydrogen from refined crude oil without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Coal:
         description: hydrogen from coal
-        tier: "2"
+        tier: ^1
     - Hydrogen|Coal|w/ CCS:
         description: hydrogen from coal in combination with carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Coal|w/o CCS:
         description: hydrogen from coal without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Gas:
         description: hydrogen from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Hydrogen|Gas|w/ CCS:
         description: hydrogen from fossil methane ('natural gas') in combination with
           carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Gas|w/o CCS:
         description: hydrogen from fossil methane ('natural gas') without carbon capture
           and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Electricity:
         description: hydrogen from electrolysis
-        tier: "2"
+        tier: ^1
     - Hydrogen|Nuclear:
         description: hydrogen from nuclear energy
           (e.g. thermochemical water splitting with nuclear heat)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Solar:
         description: hydrogen from solar energy
           (e.g. thermochemical water splitting with solar heat)
-        tier: "2"
+        tier: ^1
     - Hydrogen|Other:
         description: hydrogen from other sources
-        tier: "2"
+        tier: ^1
 
     - Heat:
         description: centralized heat
-        tier: "1"
     - Heat|Biomass:
         description: centralized heat from biomass, including biogas
-        tier: "2"
+        tier: ^1
     - Heat|Biomass|w/ CCS:
         description: centralized heat from biomass in combination with carbon capture
           and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Biomass|w/o CCS:
         description: centralized heat from biomass without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Fossil:
         description: centralized heat from fossil fuels including natural gas, oil and coal
-        tier: "2"
+        tier: ^1
     - Heat|Fossil|w/ CCS:
         description: centralized heat from fossil fuels including natural gas, oil and coal
           in combination with carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Fossil|w/o CCS:
         description: centralized heat from fossil fuels including natural gas, oil and coal
           without carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Oil:
         description: centralized heat from refined crude oil
-        tier: "2"
+        tier: ^1
     - Heat|Oil|w/ CCS:
         description: centralized heat from refined crude oil in combination with carbon
           capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Oil|w/o CCS:
         description: centralized heat from refined crude oil without carbon capture and
           storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Coal:
         description: centralized heat from coal including lignite
-        tier: "2"
+        tier: ^1
     - Heat|Coal|w/ CCS:
         description: centralized heat from coal including lignite in combination with
           carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Coal|w/o CCS:
         description: centralized heat from coal including lignite without carbon capture
           and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Gas:
         description: centralized heat from fossil methane ('natural gas')
-        tier: "2"
+        tier: ^1
     - Heat|Gas|w/ CCS:
         description: centralized heat from fossil methane ('natural gas') in combination
           with carbon capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Gas|w/o CCS:
         description: centralized heat from fossil methane ('natural gas') without carbon
           capture and storage (CCS)
-        tier: "2"
+        tier: ^1
     - Heat|Hydrogen:
         description: centralized heat from hydrogen
-        tier: "2"
+        tier: ^1
     - Heat|Hydrogen|Fossil:
         description: centralized heat using hydrogen from fossils
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Heat|Hydrogen|Biomass:
         description: centralized heat using hydrogen generated from biomass
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Heat|Hydrogen|Electricity:
         description: centralized heat using hydrogen from electrolysis
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Heat|Hydrogen|Other:
         description: centralized heat using hydrogen from other sources
         unit: EJ/yr
-        tier: "3"
+        tier: ^2
     - Heat|Geothermal:
         description: centralized heat from geothermal energy excluding ground-source heat pumps
-        tier: "2"
+        tier: ^1
     - Heat|Electricity:
         description: centralized heat from electricity
-        tier: "2"
+        tier: ^1
     - Heat|Nuclear:
         description: centralized heat from nuclear energy
-        tier: "2"
+        tier: ^1
     - Heat|Solar:
         description: centralized heat from solar energy
-        tier: "2"
+        tier: ^1
     - Heat|Other:
         description: centralized heat from sources that do not fit any other category
-        tier: "2"
+        tier: ^1


### PR DESCRIPTION
Per a nudge by @gunnar-pik, this PR uses a new nomenclature-feature to assign different tiers from tag-lists.

The tier is defined in the variable - if a tag-list is used for that variable, the tag-item can increment the variable-tier using `^1` or `^2`. This way, final-energy variables at a "high" aggregate, e.g *Final Energy|Agriculture|Electricity* keep the tier-1 assignment, but "higher-resolution" variables like *Final Energy|Non-Energy Use|Non-Ferrous Metals|Liquids|Electricity* have a higher tier-value.

See the attached file for a simple view of the resulting tier-assignment.
[final-energy-with-tier.xlsx](https://github.com/user-attachments/files/17784067/final-energy-with-tier.xlsx)

closes #212
