### PR TITLE
Implement tiers for emissions variables

### DIFF
--- a/definitions/variable/emissions/carbon-removal.yaml
+++ b/definitions/variable/emissions/carbon-removal.yaml
@@ -67,6 +67,6 @@
 - Carbon Removal|{Other Carbon Removal Option}:
     description: Gross removals of carbon dioxide (CO2) by {Other Carbon Removal Option}
     unit: Mt CO2/yr
-    tier: "{Other Carbon Removal Option}"
+    tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -12,6 +12,7 @@
       contributions. For positive contributions only, see
       "Gross Emissions|*").
     unit: "{Level-1 Species}"
+    tier: 1
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-1 Species}|AFOLU
@@ -25,8 +26,10 @@
     description: Gross emissions of carbon dioxide (CO2), not accounting for
       negative emissions, for example from bioenergy with CCS (BECCS), direct air carbon capture
       or agriculture, forestry and other land use (AFOLU)
-    notes: For net emissions (accounting for negative emissions), see "Emissions|CO2".
     unit: Mt CO2/yr
+    tier: 1
+    notes: For net emissions (accounting for negative emissions), see "Emissions|CO2".
+
 
 - Emissions|{Level-2 Species}|AFOLU:
     description: Emissions of {Level-2 Species} from agriculture, forestry
@@ -38,6 +41,7 @@
       This is reporting the sum of sources and sinks including land-use methods such as
       soil carbon sequestration, biochar, forestry, and re/afforestation and agroforestry.
     unit: "{Level-2 Species}"
+    tier: 1
     notes: This variable uses the model/scientific definition of AFOLU, and does
       not align with the reporting of national greenhouse gas inventories (NGHGI).
       For the NGHGI variable reporting, please see "Emissions|*|AFOLU [NGHGI]".
@@ -55,44 +59,53 @@
       see "Emissions|CO2|AFOLU". Emissions reported in this category represent
       fluxes from the land pool to the atmosphere.
     unit: Mt CO2/yr
+    tier: 1
 
 - Emissions|{Level-3 Species}|AFOLU|Agriculture:
     description: Emissions of {Level-3 Species} from the agriculture sector
       (IPCC 1996 category 4; IPCC 2006 category 3A and 3C except 3C1)
     unit: "{Level-3 Species}"
+    tier: 2
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock:
     description: Emissions of {Level-3 Species} from livestock in the agriculture sector
       (IPCC 1996 category 4A and 4B; IPCC 2006 category 3A)
     unit: "{Level-3 Species}"
+    tier: 2
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Enteric Fermentation:
     description: Emissions of {Level-3 Species} from enteric fermentation of livestock
       (IPCC 1996 category 4A; IPCC 2006 category 3A1)
       in the agriculture sector
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Livestock|Manure Management:
     description: Emissions of {Level-3 Species} from processes involving
       manure (waste) management in Livestock in the agriculture sector
       (IPCC 1996 category 4B; IPCC 2006 category 3A2)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Rice:
     description: Emissions of {Level-3 Species} from rice cultivation
       (IPCC 1996 category 4C; IPCC 2006 category 3C7)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Agriculture|Managed Soils:
     description: Emissions of {Level-3 Species} from soil management practices
       in the agriculture sector
       (IPCC 1996 category 4D; IPCC 2006 category 3C4 and 3C5)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Agricultural Waste Burning:
     description: Emissions from agricultural waste burning
       (IPCC 1996 category 4F; partially IPCC 2006 category 3C1)
     unit: "{Level-3 Species}"
+    tier: 2
     notes: Also sometimes known as 'biomass burning' or 'open agricultural burning'
 - Emissions|{Level-3 Species}|AFOLU|Land:
     description: Emissions of {Level-3 Species} from forestry and other land use and
       land use change. Removals in this variable include agroforestry, re/afforestation,
       biochar, soil carbon management and forest management.
     unit: "{Level-3 Species}"
+    tier: 2
     components:
       - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands
       - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change
@@ -104,19 +117,22 @@
       all or part of the year (e.g., peatland) and that does not fall
       into the forest land, cropland, grassland or settlements
       categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4)
+    unit: "{Level-3 Species}"
+    tier: 3
     notes: Includes reservoirs as a managed sub-division and
       natural rivers and lakes as unmanaged sub-divisions. Includes drained
       and rewetted wetlands, does not include natural emissions from intact wetlands.
-    unit: "{Level-3 Species}"
 - Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change:
     description: Emissions and removals from forest land, cropland, grassland,
       settlements, and other land that cannot be accommodated in other categories
       (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4).
     unit: "{Level-3 Species}"
+    tier: 3
     notes: Only includes anthropogenic emissions. Does not include wetlands.
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires:
     description: Emissions from land fires and deforestation & degradation fires
     unit: "{Level-3 Species}"
+    tier: 3
     components:
       - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning
       - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Forest Burning
@@ -124,31 +140,37 @@
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Peat Burning:
     description: Emissions from peat fires
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Forest Burning:
     description: Emissions from boreal forest fires, temperate forest fires,
       and tropical deforestation & degradation fires
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Land|Fires|Grassland Burning:
     description: Emissions from savanna, grassland, and shrubland fires
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products:
     description: Emissions and removals from harvested wood products (HWP)
       (no clear IPCC 1996 category; IPCC 2006 category 3D1)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|AFOLU|Land|Other:
     description: Emissions and removals from land that cannot be
       accommodated in other categories (no clear IPCC 1996 category;
       IPCC 2006 category 3D2)
     unit: "{Level-3 Species}"
+    tier: 3
 
 - Emissions|{Level-2 Species}|AFOLU [NGHGI]:
     description: Emissions of {Level-2 Species} from agriculture, forestry
       and other land use (IPCC 1996 category 4, 5; IPCC 2006 category 3) in line
       with the national greenhouse gas inventories (NGHGI).
     unit: "{Level-2 Species}"
+    tier: 2
     notes: This variable is optional, for instance used for comparison with national
       greenhouse gas inventories, but is not used for driving climate model simulations,
-      and also not a component of "Emissions|*",  for which the variable "Emissions|*|AFOLU"
+      and also not a component of "Emissions|*", for which the variable "Emissions|*|AFOLU"
       with model/scientific definition is used.
 
 - Emissions|{Level-3 Species}|Energy and Industrial Processes:
@@ -157,6 +179,7 @@
       including emissions from international bunker fuels. This is the sum of sources and sinks, and
       includes negative emisisons in these sectors, for instance from bioenergy with CCS (BECCS)
     unit: "{Level-3 Species}"
+    tier: 2
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-3 Species}|Energy
@@ -167,6 +190,7 @@
       including emissions from international bunker fuels, not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 2
     components:
       - Gross Emissions|CO2|Energy
       - Gross Emissions|CO2|Industrial Processes
@@ -178,6 +202,7 @@
       emissions from carbon capture and removal using BECCS and other forms of CCS on energy supply
       and demand for instance for Oil, Gas, and Coal, as well as bio-oil storage and synthetic fuels
     unit: "{Level-2 Species}"
+    tier: 1
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
     components:
       - Emissions|{Level-2 Species}|Energy|Supply
@@ -187,6 +212,8 @@
       including fugitive emissions from fuels (IPCC category 1A, 1B), not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 1
+
 - Emissions|{Level-2 Species}|Energy|Supply:
     description: Emissions of {Level-2 Species} from fuel combustion and fugitive emissions
       from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
@@ -195,6 +222,7 @@
       fugitive emissions from fuels (IPCC category 1B) and emissions from carbon dioxide
       transport and storage (IPCC category 1C)
     unit: "{Level-2 Species}"
+    tier: 1
 - Gross Emissions|CO2|Energy|Supply:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion and fugitive emissions
       from fuels, including electricity and heat production and distribution (IPCC category 1A1a),
@@ -204,6 +232,7 @@
       transport and storage (IPCC category 1C), not accounting for
       removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 1
 - Emissions|{Level-2 Species}|Energy|Supply|Combustion:
     description: Emissions of {Level-2 Species} from fuel combustion in energy supply,
       including electricity and heat production and distribution (IPCC category 1A1a),
@@ -211,40 +240,48 @@
       IPCC category 1Ab, 1Ac), incl. pipeline transportation (IPCC category 1A3ei) and
       emissions from carbon dioxide transport and storage (IPCC category 1C)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Supply|Fugitive:
     description: Fugitive emissions of {Level-2 Species} from fuels in energy extraction,
       processing, storage and transport (IPCC category 1B)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Supply|Electricity:
     description: Emissions of {Level-2 Species} for electricity generation
     unit: "{Level-2 Species}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Supply|Electricity:
     description: Gross emissions of carbon dioxide (CO2) for electricity generation,
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Supply|{Secondary Fuel Level 2}:
     description: Emissions of {Level-2 Species} for production of {Secondary Fuel Level 2}
     unit: "{Level-2 Species}"
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Supply|{Secondary Fuel Level 2}:
     description: Gross emissions of carbon dioxide (CO2) for production of {Secondary Fuel Level 2},
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Emissions|CO2|Energy|Supply|Autoproduction:
     description: Emissions of carbon dioxide (CO2) for own-use energy supply
     unit: Mt CO2/yr
+    tier: 2
 - Gross Emissions|CO2|Energy|Supply|Autoproduction:
     description: Gross emissions of carbon dioxide (CO2) for own-use energy supply,
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Supply|Other:
     description: Emissions of {Level-2 Species} for other categories of energy supply
     unit: "{Level-2 Species}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Supply|Other:
     description: Gross emissions of carbon dioxide (CO2) for other categories of energy supply,
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 2
 
 - Emissions|{Level-2 Species}|Energy|Demand:
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2),
@@ -254,6 +291,7 @@
       This is the sum of sources and sinks, including negative emissions such as the demand-side use
       of bioenergy with CCS (BECCS)
     unit: "{Level-2 Species}"
+    tier: 1
 - Gross Emissions|CO2|Energy|Demand:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
       residential, commercial, institutional sectors and agriculture, forestry,
@@ -261,52 +299,65 @@
       (IPCC category 1A3), excluding pipeline emissions (IPCC category 1A3ei),
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 1
 - Emissions|{Level-2 Species}|Energy|Demand|Industry:
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)
     unit: "{Level-2 Species}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
+    tier: 2
 - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
     unit: Mt CO2/yr
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial and AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in residential,
       commercial and institutional sectors (IPCC category 1A4a and 1A4b)
       and agriculture, forestry and fishing (AFOFI) (IPCC category 1A4c)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial:
     description: Emissions of {Level-2 Species} from fuel combustion in residential,
       commercial and institutional sectors (IPCC category 1A4a and 1A4b)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Residential:
     description: Emissions of {Level-2 Species} from fuel combustion in the residential
       sector (IPCC category 1A4b)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Commercial:
     description: Emissions of {Level-2 Species} from fuel combustion in the commercial
       and institutional sectors (IPCC category 1A4a)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Transportation:
     description: Emissions of {Level-2 Species} from fuel combustion in transportation (IPCC category 1A3),
       excluding emissions from international bunker fuels (IPCC category 1A3ai and 1A3di),
       excluding pipeline emissions (IPCC category 1A3ei)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Bunkers:
     description: Emissions of {Level-2 Species} from international bunker fuels
       (IPCC category 1A3ai and 1A3di)
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Bunkers|{Bunker Sector}:
     description: Emissions of {Level-2 Species} from bunker fuels for {Bunker Sector}
     unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Other Sector:
     description: Emissions of {Level-2 Species} from fuel combustion in other sectors
     unit: "{Level-2 Species}"
+    tier: 2
 
 - Emissions|{Level-3 Species}|Industrial Processes:
     description: Emissions of {Level-3 Species} from industrial processes
@@ -314,45 +365,55 @@
       and sinks, including negative emissions such as those from cement carbonation
       processes and other forms of capture and storage on industrial processes
     unit: "{Level-3 Species}"
+    tier: 1
     notes: For a breakdown of carbon removals, see the "Carbon Removal|*" tree
 - Gross Emissions|CO2|Industrial Processes:
     description: Gross emissions of carbon dioxide (CO2) from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E), not accounting for negative emissions
       from carbon removal processes such as from cement production
     unit: Mt CO2/yr
+    tier: 1
 - Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}:
     description: Emissions of {Level-3 Species} from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Non-Energy Sector}
     unit: "{Level-3 Species}"
+    tier: 2
 - Emissions|{Level-3 Species}|Industrial Processes|{Industrial-Process Sector}:
     description: Emissions of {Level-3 Species} from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Industrial-Process Sector}
     unit: "{Level-3 Species}"
+    tier: 2
 
 - Emissions|{Level-3 Species}|Product Use:
     description: Emissions of {Level-3 Species} from product use (IPCC category 2D, 2F
       and 2G)
     unit: "{Level-3 Species}"
+    tier: 2
 - Emissions|{Level-3 Species}|Product Use|Non-Energy Use:
     description: Emissions of {Level-3 Species} from non-energy products from fuels
       (IPCC category 2D1 and 2D2)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|Product Use|Solvents:
     description: Emissions of {Level-3 Species} from solvents use (IPCC category 2D3)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|Product Use|ODS Substitutes:
-    description: Emissions of {Level-3 Species} from use of subtitutes of ozone
+    description: Emissions of {Level-3 Species} from use of substitutes of ozone
       depleting substances (ODS) (IPCC categories 2F)
     unit: "{Level-3 Species}"
+    tier: 3
 - Emissions|{Level-3 Species}|Product Use|Other:
     description: Emissions of {Level-3 Species} from other product use or manufacturing
     unit: "{Level-3 Species}"
+    tier: 3
 
 - Emissions|{Level-2 Species}|Waste:
     description: Emissions of {Level-2 Species} from waste of fossil-based products
       through incineration or decomposition (IPCC 1996 category 6; IPCC 2006 category 4),
       not including emissions from organic waste handling and decay
     unit: "{Level-2 Species}"
+    tier: 2
 
 - Emissions|{Level-2 Species}|Other:
     description: Emissions of {Level-2 Species} from other sources (IPCC 1996 category 7;
@@ -360,6 +421,7 @@
       cannot be accommodated in other categories
     notes: This will be treated as a flux from the fossil reservoir to the atmosphere in climate models.
     unit: "{Level-2 Species}"
+    tier: 2
 
 - Emissions|{Level-3 Species}|Other Capture and Removal:
     description: Capture and removal of atmospheric {Level-3 Species} using other net-negative
@@ -368,6 +430,7 @@
       products in building elements or plastics, mineral products, ocean fertilization,
       ocean alkalinity enhancement (OAE), and direct ocean capture.
     unit: "{Level-3 Species}"
+    tier: 2
     notes: This timeseries should be reported as negative values so that subcategories of
       emissions add up to net emissions `Emissions|{Level-3 Species}`. For a breakdown of carbon
       removals, see the "Carbon Removal|*" tree

--- a/definitions/variable/energy/secondary-energy-non-electricity.yaml
+++ b/definitions/variable/energy/secondary-energy-non-electricity.yaml
@@ -1,19 +1,19 @@
 - Secondary Energy|{Secondary Fuel Level 3}:
     description: Production of {Secondary Fuel Level 3}
     unit: EJ/yr
-    tier: "{Secondary Fuel Level 3}"
+    tier: 1
 
 - Capacity|{Secondary Fuel Level 2}:
     description: Installed (available) capacity to produce {Secondary Fuel Level 2}
     unit: GW
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Capacity|{Secondary Fuel Level 2}|{CCS}:
     description: Installed (available) capacity to produce {Secondary Fuel Level 2} {CCS}
     unit: GW
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
 - Capacity Additions|{Secondary Fuel Level 2}:
     description: Total annual new capacity installation to produce {Secondary Fuel Level 2}
     unit: GW/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 2
     notes: This variable should be computed as yearly average additions between the previous
       and the current reported time step.

--- a/definitions/variable/macro-economy/investment.yaml
+++ b/definitions/variable/macro-economy/investment.yaml
@@ -27,16 +27,17 @@
 - Investment|Energy Supply|{Secondary Fuel Level 2}:
     description: Investments for the production of {Secondary Fuel Level 2}
     unit: billion USD_2010/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 1
     notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 - Investment|Energy Supply|{Secondary Fuel Level 2}|{CCS}:
     description: Investments for the production of {Secondary Fuel Level 2} {CCS}
     unit: billion USD_2010/yr
-    tier: "{Secondary Fuel Level 2}"
+    tier: 1
     notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 
 - Investment|Energy Efficiency:
     description: Investments in efficiency-increasing components of energy demand
     unit: billion USD_2010/yr
+    tier: 2


### PR DESCRIPTION
This PR adds tiers for emissions variables, and also fixes wrong tier-assignment for investment, secondary-energy, capacity (addition) and carbon-removal. Follow-up to #215.

fyi @IAMconsortium/common-definitions-emissions 