### PR TITLE
Add technology-specific variables for techno-economic parameters

### DIFF
--- a/definitions/variable/techno-economic/electricity-generation.yaml
+++ b/definitions/variable/techno-economic/electricity-generation.yaml
@@ -2,12 +2,25 @@
     description: Capital cost of a newly installed plant to generate electricity
       from {Electricity Source}
     unit: USD_2010/kW
+- Capital Cost|Electricity|{Electricity Source}|*:
+    description: Capital cost of a newly installed plant to generate electricity
+      from {Electricity Source} for a specific technology
+    unit: USD_2010/kW
 - Efficiency|Electricity|{Electricity Source}:
     description: Conversion efficiency per unit of primary energy of a newly installed
       plant to generate electricity from {Electricity Source}
     unit: "%"
     range: [ 0,100 ]
+- Efficiency|Electricity|{Electricity Source}|*:
+    description: Conversion efficiency per unit of primary energy of a newly installed
+      plant to generate electricity from {Electricity Source} for a specific technology
+    unit: "%"
+    range: [ 0,100 ]
 - Lifetime|Electricity|{Electricity Source}:
     description: Technical lifetime of a newly installed plant to generate electricity
       from {Electricity Source}
+    unit: years
+- Lifetime|Electricity|{Electricity Source}|*:
+    description: Technical lifetime of a newly installed plant to generate electricity
+      from {Electricity Source} for a specific technology
     unit: years

--- a/definitions/variable/techno-economic/other-energy-transformation-technologies.yaml
+++ b/definitions/variable/techno-economic/other-energy-transformation-technologies.yaml
@@ -1,11 +1,24 @@
 - Capital Cost|{Secondary Fuel Level 3}:
     description: Capital cost of a newly installed plant to produce {Secondary Fuel Level 3}
     unit: USD_2010/kW
+- Capital Cost|{Secondary Fuel Level 3}|*:
+    description: Capital cost of a newly installed plant to produce {Secondary Fuel Level 3}
+      for a specific technology
+    unit: USD_2010/kW
 - Efficiency|{Secondary Fuel Level 3}:
     description: Conversion efficiency per unit of primary energy of a newly installed
       plant to produce {Secondary Fuel Level 3}
     unit: "%"
     range: [ 0,100 ]
+- Efficiency|{Secondary Fuel Level 3}|*:
+    description: Conversion efficiency per unit of primary energy of a newly installed
+      plant to produce {Secondary Fuel Level 3} for a specific technology
+    unit: "%"
+    range: [ 0,100 ]
 - Lifetime|{Secondary Fuel Level 3}:
     description: Technical lifetime of a newly installed plant to produce {Secondary Fuel Level 3}
+    unit: years
+- Lifetime|{Secondary Fuel Level 3}|*:
+    description: Technical lifetime of a newly installed plant to produce {Secondary Fuel Level 3}
+      for a specific technology
     unit: years


### PR DESCRIPTION
This PR adds variables for technology-specific parameters. The `*` is a wildcard so that any technology can be added to a variable, e.g. 

> Capital Cost|Electricity|Biomass|1
> Capital Cost|Electricity|Biomass|CCGT

can be used in reporting.

Requires https://github.com/IAMconsortium/nomenclature/issues/432 to validate the units as well as the variable names.