### PR TITLE
Add Domestic Aviation variable

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -340,6 +340,11 @@
       excluding pipeline emissions (IPCC category 1A3ei)
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Domestic Aviation:
+    description: Emissions of {Level-2 Species} from domestic aviation, being all aviation not reported 
+      under international aviation bunkers emisisons. 
+    unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -351,6 +351,28 @@
       under international aviation bunkers emisisons. 
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Bus:
+    description: Emissions of {Level-2 Species} from the transportation sector by bus
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Light Duty Vehicle:
+    description: Emissions of {Level-2 Species} from  the transportation sector with light-duty vehicles
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|:
+    description: Emissions of {Level-2 Species} from the trucking sector
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Rail:
+    description: Emissions of {Level-2 Species} from the rail transportation sector
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Domestic Shipping:
+    description: Emissions of {Level-2 Species} from domestic shipping sector
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Passenger:
+    description: Emissions of {Level-2 Species} from passenger transportation sector excluding international aviation
+      and shipping
+    tier: 3
+- Emissions|{Level-2 Species}|Energy|Demand|Transportation|Freight:
+    description: Emissions of {Level-2 Species} from freight transportation sector excluding international aviation and shipping
+    tier: 3
 - Emissions|{Level-2 Species}|Energy|Demand|AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -300,6 +300,12 @@
       not accounting for removals from the atmosphere
     unit: Mt CO2/yr
     tier: 1
+    components:
+      - Emissions|{Level-2 Species}|Energy|Demand|Industry
+      - Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial and AFOFI
+      - Emissions|{Level-2 Species}|Energy|Demand|Transportation
+      - Emissions|{Level-2 Species}|Energy|Demand|Bunkers
+      - Emissions|{Level-2 Species}|Energy|Demand|Other Sector
 - Emissions|{Level-2 Species}|Energy|Demand|Industry:
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)
     unit: "{Level-2 Species}"
@@ -363,6 +369,15 @@
     description: Emissions of {Level-2 Species} from fuel combustion in other sectors
     unit: "{Level-2 Species}"
     tier: 2
+    
+- Emissions|{Level-2 Species}|Energy|Demand|Aircraft:
+    description: Emissions of {Level-2 Species} from all aircraft, containing both domestic and international aviation. 
+    unit: "{Level-2 Species}"
+    tier: 2
+    components: 
+      - Emissions|{Level-2 Species}|Energy|Demand|Transportation|Domestic Aviation
+      - Emissions|{Level-2 Species}|Energy|Demand|Bunkers|International Aviation
+
 
 - Emissions|{Level-3 Species}|Industrial Processes:
     description: Emissions of {Level-3 Species} from industrial processes


### PR DESCRIPTION
Addresses #227.

@danielhuppmann we need this domestic aviation variable for CMIP7. 
But not necessarily any other differentiation. 
Should we add an "Other" category at the same level, or are there more categories that you suggest to add at this level?

