### PR TITLE
Add carbon-capture variables for energy supply

### DIFF
--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -26,6 +26,51 @@
     notes: Values should be reported as positive numbers.
     navigate: Carbon Capture|{Carbon Capture Source}
     engage: Carbon Capture|{Carbon Capture Source}
+- Carbon Capture|Energy|Supply:
+    description: Captured carbon dioxide (CO2) in energy supply sectors
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Supply|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) from {Carbon Capture Source}
+      in energy supply sectors
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|{Carbon Capture Source}|Energy|Supply
+    engage: Carbon Capture|{Carbon Capture Source}|Energy|Supply
+- Carbon Capture|Energy|Supply|Electricity:
+    description: Captured carbon dioxide (CO2) during electricity generation
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Supply|Electricity|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) during electricity generation
+      from {Carbon Capture Source}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|{Carbon Capture Source}|Energy|Supply|Electricity
+    engage: Carbon Capture|{Carbon Capture Source}|Energy|Supply|Electricity
+- Carbon Capture|Energy|Supply|{Secondary Fuel Level 1}:
+    description: Captured carbon dioxide (CO2) during production of {Secondary Fuel Level 1}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Supply|{Secondary Fuel Level 1}|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) during production of {Secondary Fuel Level 1}
+      using {Carbon Capture Source}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|{Carbon Capture Source}|Energy|Supply|{Secondary Fuel Level 1}
+    engage: Carbon Capture|{Carbon Capture Source}|Energy|Supply|{Secondary Fuel Level 1}
 
 - Carbon Capture|Industrial Processes:
     description: Captured carbon dioxide (CO2) from industrial processes

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -11,12 +11,22 @@
       - Carbon Capture|Leakage
       - Carbon Capture|Utilization
 
-- Carbon Capture|{Carbon Capture Source}:
+- Carbon Capture|Energy:
+    description: Captured carbon dioxide (CO2) from energy use in supply and demand sectors
+      (IPCC category 1A, 1B)
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|{Carbon Capture Source}:
     description: Captured carbon dioxide (CO2) from {Carbon Capture Source}
     unit: Mt CO2/yr
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|{Carbon Capture Source}
+    engage: Carbon Capture|{Carbon Capture Source}
+
 - Carbon Capture|Industrial Processes:
     description: Captured carbon dioxide (CO2) from industrial processes
       (e.g., cement production), not including energy use
@@ -24,6 +34,7 @@
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
+
 - Carbon Capture|Direct Air Capture:
     description: Captured carbon dioxide (CO2) from direct air capture
     unit: Mt CO2/yr

--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -19,13 +19,15 @@
     lower_bound: 0
     notes: Values should be reported as positive numbers.
 - Carbon Capture|Energy|{Carbon Capture Source}:
-    description: Captured carbon dioxide (CO2) from {Carbon Capture Source}
+    description: Captured carbon dioxide (CO2) from {Carbon Capture Source} in supply
+      and demand sectors (IPCC category 1A, 1B)
     unit: Mt CO2/yr
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
     navigate: Carbon Capture|{Carbon Capture Source}
     engage: Carbon Capture|{Carbon Capture Source}
+
 - Carbon Capture|Energy|Supply:
     description: Captured carbon dioxide (CO2) in energy supply sectors
     unit: Mt CO2/yr


### PR DESCRIPTION
This PR implements more detailed variables for energy-supply carbon-capture variables per a list sent by @strefler.

There  are three important changes compared to earlier projects (NAVGATE and ENGAGE):
- Add additional variable "Carbon Capture|Energy" and subsectors to report how much capture happens in total in the energy system
- Rename "Carbon Capture|[Fossil/Biomass]" to "Carbon Capture|Energy|[Fossil/Biomass]" for clarity
- Reorder the variable-names to have fossil/biomass/synfuels at the end, similar to how energy-variables are structured