### PR TITLE
Add variable for carbon-capture in industry

### DIFF
--- a/definitions/variable/emissions/carbon-management.yaml
+++ b/definitions/variable/emissions/carbon-management.yaml
@@ -74,6 +74,48 @@
     navigate: Carbon Capture|{Carbon Capture Source}|Energy|Supply|{Secondary Fuel Level 1}
     engage: Carbon Capture|{Carbon Capture Source}|Energy|Supply|{Secondary Fuel Level 1}
 
+- Carbon Capture|Energy|Demand:
+    description: Captured carbon dioxide (CO2) during energy consumption
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Demand|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) during direct consumption of {Carbon Capture Source}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Demand|Industry:
+    description: Captured carbon dioxide (CO2) during energy consumption in industry
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+- Carbon Capture|Energy|Demand|Industry|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) during use of {Carbon Capture Source} in industry
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|Industry|{Carbon Capture Source}
+    engage: Carbon Capture|Industry|{Carbon Capture Source}
+- Carbon Capture|Energy|Demand|Industry|{Industry Sector}:
+    description: Captured carbon dioxide (CO2) during energy consumption in {Industry Sector}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|Industry|{Industry Sector}
+- Carbon Capture|Energy|Demand|Industry|{Industry Sector}|{Carbon Capture Source}:
+    description: Captured carbon dioxide (CO2) during use of {Carbon Capture Source}
+      in {Industry Sector}
+    unit: Mt CO2/yr
+    tier: 2
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|Industry|{Carbon Capture Source}|{Industry Sector}
+
 - Carbon Capture|Industrial Processes:
     description: Captured carbon dioxide (CO2) from industrial processes
       (e.g., cement production), not including energy use
@@ -81,6 +123,14 @@
     tier: 1
     lower_bound: 0
     notes: Values should be reported as positive numbers.
+- Carbon Capture|Industrial Processes|{Industry Sector}:
+    description: Captured carbon dioxide (CO2) from industrial processes
+      in the {Industry Sector}, not including energy use
+    unit: Mt CO2/yr
+    tier: 1
+    lower_bound: 0
+    notes: Values should be reported as positive numbers.
+    navigate: Carbon Capture|Industry|Industrial Processes|{Industry Sector}
 
 - Carbon Capture|Direct Air Capture:
     description: Captured carbon dioxide (CO2) from direct air capture

--- a/definitions/variable/industry/tag_industry_sectors.yaml
+++ b/definitions/variable/industry/tag_industry_sectors.yaml
@@ -1,0 +1,13 @@
+- Industry Sector:
+    - Chemicals:
+        description: production of chemicals
+    - Iron and Steel:
+        description: production of iron and steel
+    - Non-Ferrous Metals:
+        description: production of non-ferrous metals including aluminium
+    - Non-Metallic Minerals:
+        description: production of non-metallic minerals including cement
+    - Pulp and Paper:
+        description: production of pulp and paper
+    - Other Sector:
+        description: other industrial sectors


### PR DESCRIPTION
This PR implements variables for carbon-capture in industry, distinguishing between energy consumption and industrial processes based on a list sent by @strefler.

Similar to #230, this PR restructures the variable tree to more closely aligned with emissions and energy variables. In the process, we are getting rid of confusing/overlappung variables like
- Carbon Capture|Fossil|Energy|Demand|Industry
- Carbon Capture|Industry|Fossil (which also seems to include industrial processes)
