### PR TITLE
Add variables for road transportation service demand

### DIFF
--- a/definitions/variable/transport/energy-services.yaml
+++ b/definitions/variable/transport/energy-services.yaml
@@ -2,11 +2,13 @@
     description: Energy service demand for passenger transport on roads in light duty vehicles
     unit: billion pkm/yr
     tier: 2
+    navigate: Energy Service|Transportation|Road|LDV
 - Energy Service|Transportation|Passenger|Road|Light-Duty Vehicles|{Drive Type}:
     description: Energy service demand for passenger transport on roads in light duty vehicles
       with {Drive Type}
     unit: billion pkm/yr
     tier: 2
+    navigate: Energy Service|Transportation|Road|LDV|{Drive Type}
 - Energy Service|Transportation|Freight|Truck:
     description: Energy service demand for freight transport on roads in trucks
     unit: billion tkm/yr
@@ -16,3 +18,4 @@
       with {Drive Type}
     unit: billion tkm/yr
     tier: 2
+    navigate: Energy Service|Transportation|Freight|Truck|{Drive Type}

--- a/definitions/variable/transport/energy-services.yaml
+++ b/definitions/variable/transport/energy-services.yaml
@@ -1,0 +1,18 @@
+- Energy Service|Transportation|Passenger|Road|Light-Duty Vehicles:
+    description: Energy service demand for passenger transport on roads in light duty vehicles
+    unit: billion pkm/yr
+    tier: 2
+- Energy Service|Transportation|Passenger|Road|Light-Duty Vehicles|{Drive Type}:
+    description: Energy service demand for passenger transport on roads in light duty vehicles
+      with {Drive Type}
+    unit: billion pkm/yr
+    tier: 2
+- Energy Service|Transportation|Freight|Truck:
+    description: Energy service demand for freight transport on roads in trucks
+    unit: billion tkm/yr
+    tier: 2
+- Energy Service|Transportation|Freight|Truck|{Drive Type}:
+    description: Energy service demand for freight transport on roads in trucks
+      with {Drive Type}
+    unit: billion tkm/yr
+    tier: 2

--- a/definitions/variable/transport/tag_drive-types.yaml
+++ b/definitions/variable/transport/tag_drive-types.yaml
@@ -1,0 +1,9 @@
+- Drive Type:
+    - BEV:
+        description: battery-electric drive
+    - FCEV:
+        description: fuel-cell-electric drive
+    - PHEV:
+        description: plug-in hybrid drive
+    - ICE:
+        description: internal combustion engine drive not including plug-in hybrids

--- a/definitions/variable/transport/tag_drive-types.yaml
+++ b/definitions/variable/transport/tag_drive-types.yaml
@@ -1,9 +1,13 @@
 - Drive Type:
-    - BEV:
-        description: battery-electric drive
-    - FCEV:
-        description: fuel-cell-electric drive
-    - PHEV:
-        description: plug-in hybrid drive
-    - ICE:
-        description: internal combustion engine drive not including plug-in hybrids
+    - Battery-Electric:
+        description: battery-electric drive (BEV)
+        navigate: BEV
+    - Fuel-Cell-ELectric:
+        description: fuel-cell-electric drive (FCEV)
+        navigate: FCEV
+    - Plug-in Hybrid:
+        description: plug-in hybrid drive (PHEV)
+        navigate: PHEV
+    - Internal Combustion:
+        description: internal combustion engine drive not including plug-in hybrids (ICE)
+        navigate: ICE

--- a/definitions/variable/transport/tag_drive-types.yaml
+++ b/definitions/variable/transport/tag_drive-types.yaml
@@ -2,7 +2,7 @@
     - Battery-Electric:
         description: battery-electric drive (BEV)
         navigate: BEV
-    - Fuel-Cell-ELectric:
+    - Fuel-Cell-Electric:
         description: fuel-cell-electric drive (FCEV)
         navigate: FCEV
     - Plug-in Hybrid:


### PR DESCRIPTION
Per request by @gunnar-pik, this PR adds variables for energy service demand related to road transportation.

After a brief discussion with @vruijven, this PR replaces abbreviations with more descriptive terms to be more accessible to a wider audience. A mapping from NAVIGATE to the new form is included.