### PR TITLE
Minor update AFOLU Emissions Land Use and Land-Use Change

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -122,10 +122,10 @@
     notes: Includes reservoirs as a managed sub-division and
       natural rivers and lakes as unmanaged sub-divisions. Includes drained
       and rewetted wetlands, does not include natural emissions from intact wetlands.
-- Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change:
+- Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change:
     description: Emissions and removals from forest land, cropland, grassland,
-      settlements, and other land that cannot be accommodated in other categories
-      (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B4).
+      settlements and other natural land 
+      (partially IPCC 1996 category 5; IPCC 2006 category 3B except 3B1biii, 3B2biii, 3B3biii, 3B5biv, 3B6biv and 3B4).
     unit: "{Level-3 Species}"
     tier: 3
     notes: Only includes anthropogenic emissions. Does not include wetlands.

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -114,7 +114,7 @@
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
     description: Net emissions from managed wetlands (e.g., peatland), including 
-      emissions from drained wetlands used for agriculture or forestry (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii), 
+      emissions from drained wetlands used for agriculture, forestry or other uses (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii, 3B5biv, 3B6biv), 
       and emissions from rewetted wetlands (IPCC 2006 category 3B4).
     unit: "{Level-3 Species}"
     tier: 3

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -114,7 +114,7 @@
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
     description: Net emissions from managed wetlands (e.g., peatland), including 
-      emissions from drained wetlands used for agriculture or forestry (IPCC 2006 categories 3B1, 3B2 and 3B3), 
+      emissions from drained wetlands used for agriculture or forestry (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii), 
       and emissions from rewetted wetlands (IPCC 2006 category 3B4).
     unit: "{Level-3 Species}"
     tier: 3

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -113,9 +113,10 @@
       - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
-    description: Net emissions from managed wetlands (e.g., peatland), including 
-      emissions from drained wetlands used for agriculture, forestry or other uses (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii, 3B5biv, 3B6biv), 
-      and emissions from rewetted wetlands (IPCC 2006 category 3B4).
+    description: Net emissions of {Level-3 Species} from managed wetlands (e.g., peatland),
+      including emissions from drained wetlands used for agriculture, forestry or other uses
+      (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii, 3B5biv, 3B6biv), 
+      and emissions from rewetted wetlands (IPCC 2006 category 3B4)
     unit: "{Level-3 Species}"
     tier: 3
     notes: Includes reservoirs as a managed sub-division and

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -113,10 +113,9 @@
       - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
-    description: Emissions from land that is covered or saturated by water for
-      all or part of the year (e.g., peatland) and that does not fall
-      into the forest land, cropland, grassland or settlements
-      categories (partially IPCC 1996 category 4D/5A/5B/5E; IPCC 2006 category 3B4)
+    description: Net emissions from managed wetlands (e.g., peatland), including 
+      emissions from drained wetlands used for agriculture or forestry (IPCC 2006 categories 3B1, 3B2 and 3B3), 
+      and emissions from rewetted wetlands (IPCC 2006 category 3B4).
     unit: "{Level-3 Species}"
     tier: 3
     notes: Includes reservoirs as a managed sub-division and

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -113,7 +113,7 @@
       - Emissions|{Level-3 Species}|AFOLU|Land|Harvested Wood Products
       - Emissions|{Level-3 Species}|AFOLU|Land|Other
 - Emissions|{Level-3 Species}|AFOLU|Land|Wetlands:
-    description: Net emissions of {Level-3 Species} from managed wetlands (e.g., peatland),
+    description: Emissions of {Level-3 Species} from managed wetlands (e.g., peatland),
       including emissions from drained wetlands used for agriculture, forestry or other uses
       (IPCC 2006 categories 3B1biii, 3B2biii and 3B3biii, 3B5biv, 3B6biv), 
       and emissions from rewetted wetlands (IPCC 2006 category 3B4)


### PR DESCRIPTION
This PR adresses the issue raised by @jkikstra here:
https://github.com/IAMconsortium/common-definitions/pull/226#issuecomment-2527932422

Furthermore, this PR renames 
`Emissions|{Level-3 Species}|AFOLU|Land|Other Land Use and Land-Use Change`
to 
`Emissions|{Level-3 Species}|AFOLU|Land|Land Use and Land-Use Change`
because there is already `Emissions|{Level-3 Species}|AFOLU|Land|Other` which includes `Emissions and removals from land that cannot be accommodated in other categories `

