### PR TITLE
Add tiers for price variables

### DIFF
--- a/definitions/variable/energy/energy-prices.yaml
+++ b/definitions/variable/energy/energy-prices.yaml
@@ -1,22 +1,26 @@
 - Price|Primary Energy|Biomass:
     description: Producer price for biomass
     unit: USD_2010/GJ
+    tier: 1
     weight: Primary Energy|Biomass
 - Price|Primary Energy|{Primary Fossil Fuel}:
     description: Price for {Primary Fossil Fuel} at global or regional spot markets
     unit: USD_2010/GJ
+    tier: 1
     weight: Primary Energy|{Primary Fossil Fuel}
 
 - Price|Secondary Energy|Electricity:
     definition: Electricity price at the regional wholesale-market,
       i.e. for large-scale consumers
     unit: USD_2010/GJ
+    tier: 1
     weight: Secondary Energy|Electricity
     notes: This price should include the effect of carbon prices.
 - Price|Secondary Energy|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} at the regional wholesale market,
       i.e. for large-scale consumers
     unit: USD_2010/GJ
+    tier: 1
     weight: Secondary Energy|{Secondary Fuel Level 2}
     notes: This price should include the effect of carbon prices.
 
@@ -24,19 +28,23 @@
     definition: Electricity price including transmission and distribution costs,
       including carbon prices but not including other taxes
     unit: USD_2010/GJ
+    tier: 1
     weight: Final Energy|Electricity
 - Price|Final Energy|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} including transmission and
       distribution costs, including carbon prices but not including other taxes
     unit: USD_2010/GJ
+    tier: 1
     weight: Final Energy|{Secondary Fuel Level 2}
 - Price|Final Energy|{Sector}|Electricity:
     definition: Electricity price including transmission and distribution costs,
       including carbon prices but not including other taxes
     unit: USD_2010/GJ
+    tier: 1
     weight: Final Energy|{Sector}|Electricity
 - Price|Final Energy|{Sector}|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} in the {Sector} including transmission
       and distribution costs, including carbon prices but not including other taxes
     unit: USD_2010/GJ
+    tier: 1
     weight: Final Energy|{Sector}|{Secondary Fuel Level 2}


### PR DESCRIPTION
This PR adds tiers for energy-price variable at tier 1 with tier-bump for sub-categories of energy carriers (see [this file](https://github.com/IAMconsortium/common-definitions/blob/main/definitions/variable/energy/tag_secondary_energy_carriers_level-2.yaml))

FYI @IAMconsortium/common-definitions-energy