### PR TITLE
Fix India G20 mapping for IMAGE 3.4

### DIFF
--- a/mappings/IMAGE_v3.4.yaml
+++ b/mappings/IMAGE_v3.4.yaml
@@ -174,7 +174,7 @@ common_regions:
   - China:
       - CHN
   - India:
-      - IND
+      - INDIA
   - Japan:
       - JAP
   - United States:


### PR DESCRIPTION
While working on something else, noticed this misnamed region. It raised an error in my script but I assume it doesn't in workflow repos because there is no check whether the native constituent regions belong to the same model where they are listed.