### PR TITLE
Add copper tag in energy sector tag list

### DIFF
--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -12,8 +12,11 @@
     - Industry|Non-Ferrous Metals|Aluminum:
         description: aluminum
         tier: ^1
+    - Industry|Non-Ferrous Metals|Copper:
+        description: copper
+        tier: ^2
     - Industry|Non-Ferrous Metals|Other Metals:
-        description: non-ferrous metals sector excluding aluminum
+        description: non-ferrous metals sector excluding aluminum and copper
     - Industry|Non-Metallic Minerals:
         tier: ^1
         description: non-metallic minerals sector


### PR DESCRIPTION
This PR adds `Final Energy|Industry|Non-Ferrous Metals|Copper*` variables.