### PR TITLE
Fix livestock products definition for dairy <-> eggs

### DIFF
--- a/definitions/variable/afolu/tag_livestock.yaml
+++ b/definitions/variable/afolu/tag_livestock.yaml
@@ -1,6 +1,8 @@
 - Livestock Products:
     - Dairy:
-        description: dairy products (milk, eggs)
+        description: dairy products (milk, cheese)
+    - Eggs:
+        description: eggs
     - Ruminant:
         description: ruminant meat (cattle, goat, sheep)
     - Non-Ruminant:

--- a/definitions/variable/afolu/tag_livestock.yaml
+++ b/definitions/variable/afolu/tag_livestock.yaml
@@ -1,9 +1,17 @@
 - Livestock Products:
-    - Dairy:
-        description: dairy products (milk, cheese)
-    - Eggs:
-        description: eggs
     - Ruminant:
+        description: ruminant meat (cattle, goat, sheep) and dairy products (milk, cheese)
+    - Ruminant|Meat:
         description: ruminant meat (cattle, goat, sheep)
+    - Ruminant|Dairy:
+        description: dairy products (milk, cheese)
     - Non-Ruminant:
+        description: monogastric meat (pig, poultry) and eggs
+    - Non-Ruminant|Meat:
         description: monogastric meat (pig, poultry)
+    - Non-Ruminant|Meat|Pig:
+        description: pig meat
+    - Non-Ruminant|Meat|Poultry:
+        description: poultry meat
+    - Non-Ruminant|Eggs:
+        description: eggs


### PR DESCRIPTION
Dairy is only milk and cheese but not eggs.
This PR fixes this issue by adding an extra category for eggs.