### PR TITLE
Add CEDS variable-aggregation mapping

### DIFF
--- a/ceds-mapping/ceds-variable-mapping.yaml
+++ b/ceds-mapping/ceds-variable-mapping.yaml
@@ -1,0 +1,33 @@
+- Emissions [CEDS]|CO2|Energy Sector:
+    - Emissions|CO2|Energy|Supply
+- Emissions [CEDS]|CO2|Industrial Sector:
+    - Emissions|CO2|Energy|Demand|Industry
+    - Emissions|CO2|Energy|Demand|Other Sector
+    - Emissions|CO2|Industrial Processes
+    - Emissions|CO2|Other
+- Emissions [CEDS]|CO2|Aircraft:
+    - Emissions|CO2|Energy|Demand|Transportation|Domestic Aviation
+    - Emissions|CO2|Energy|Demand|Bunkers|International Aviation
+- Emissions [CEDS]|CO2|Transportation Sector:
+    - Emissions|CO2|Energy|Demand|Transportation|Road
+    - Emissions|CO2|Energy|Demand|Transportation|Rail
+    - Emissions|CO2|Energy|Demand|Transportation|Domestic Shipping
+    - Emissions|CO2|Energy|Demand|Transportation|Other
+- Emissions [CEDS]|CO2|International Shipping:
+    - Emissions|CO2|Energy|Demand|Bunkers|International Shipping
+- Emissions [CEDS]|CO2|Residential and Commercial:
+    - Emissions|CO2|Energy|Demand|Residential and Commercial and AFOFI
+- Emissions [CEDS]|CO2|Solvents Production and Application:
+    - Emissions|CO2|Product Use
+- Emissions [CEDS]|CO2|Agriculture:
+    - Emissions|CO2|AFOLU|Agriculture
+- Emissions [CEDS]|CO2|Agricultural Waste Burning:
+    - Emissions|CO2|AFOLU|Agricultural Waste Burning
+- Emissions [CEDS]|CO2|Forest Burning:
+    - Emissions|CO2|AFOLU|Land|Fires|Forest Burning
+- Emissions [CEDS]|CO2|Grassland Burning:
+    - Emissions|CO2|AFOLU|Land|Fires|Grassland Burning
+- Emissions [CEDS]|CO2|Peat Burning:
+    - Emissions|CO2|AFOLU|Land|Fires|Peat
+- Emissions [CEDS]|CO2|Waste:
+    - Emissions|CO2|Waste

--- a/ceds-mapping/ceds-variable-mapping.yaml
+++ b/ceds-mapping/ceds-variable-mapping.yaml
@@ -28,6 +28,6 @@
 - Emissions [CEDS]|CO2|Grassland Burning:
     - Emissions|CO2|AFOLU|Land|Fires|Grassland Burning
 - Emissions [CEDS]|CO2|Peat Burning:
-    - Emissions|CO2|AFOLU|Land|Fires|Peat
+    - Emissions|CO2|AFOLU|Land|Fires|Peat Burning
 - Emissions [CEDS]|CO2|Waste:
     - Emissions|CO2|Waste


### PR DESCRIPTION
This PR adds a mapping from the standard emissions variable tree to CEDS categories, per some discussion with @jkikstra 

One complicated issue is the handling of transportation-emissions, where domestic aviation is part of "Emissions|*|Energy|Demand|Transportation" in the IAMC convention but part of "Aircraft" in CEDS.

@jkikstra suggested simply doing "Tranportation minus Domestic Aviation", but including computation-instructions goes against the spirit of a well-readable mapping.

Instead, I added two variables 
- Emissions|CO2|Energy|Demand|Transportation|Road
- Emissions|CO2|Energy|Demand|Transportation|Other

that are not yet included in the variable template.

To be discussed further bilaterally.

FIY @IAMconsortium/common-definitions-emissions 