### PR TITLE
Add Curacao and Sint Maarten

### DIFF
--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -71,7 +71,7 @@
           Ecuador, El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala,
           Guyana, Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama,
           Paraguay, Peru, Saint Kitts and Nevis, Saint Lucia,
-          Saint Vincent and the Grenadines, Sint Maarten, Suriname, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Sint Maarten (Dutch part), Suriname, Trinidad and Tobago,
           United States Virgin Islands, Uruguay, Venezuela
         ]
     - Other (R5):
@@ -161,7 +161,7 @@
           Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curaçao, Dominican Republic,
           Ecuador, El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala, Guyana,
           Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama, Paraguay,
-          Peru, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines, Sint Maarten,
+          Peru, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines, Sint Maarten (Dutch part),
           Suriname, Trinidad and Tobago, United States Virgin Islands, Uruguay, Venezuela
         ]
     - Other (R9):
@@ -220,7 +220,7 @@
           El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala, Guyana, Haiti,
           Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama, Paraguay, Peru,
           Puerto Rico, Saint Kitts and Nevis, Saint Lucia,
-          Saint Vincent and the Grenadines, Sint Maarten, Suriname, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Sint Maarten (Dutch part), Suriname, Trinidad and Tobago,
           United States Virgin Islands, Uruguay, Venezuela
         ]
     - Middle East (R10):

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -67,7 +67,7 @@
         ssp: R5.2LAM
         countries: [
           Antigua and Barbuda, Argentina, Aruba, Bahamas, Barbados, Belize,
-          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curacao, Dominican Republic,
+          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curaçao, Dominican Republic,
           Ecuador, El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala,
           Guyana, Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama,
           Paraguay, Peru, Saint Kitts and Nevis, Saint Lucia,

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -7,6 +7,7 @@
 # The R5 definitions are taken from the call for submissions
 # to the AR6 WG3 scenario ensemble
 # https://data.ece.iiasa.ac.at/ar6-scenario-submission/#/about
+# and then updated afterwards with updates in territories.
 - R5:
     - OECD & EU (R5):
         description: OECD (membership status 1990) and EU member states and candidates
@@ -66,11 +67,11 @@
         ssp: R5.2LAM
         countries: [
           Antigua and Barbuda, Argentina, Aruba, Bahamas, Barbados, Belize,
-          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Dominican Republic,
+          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curacao, Dominican Republic,
           Ecuador, El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala,
           Guyana, Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama,
           Paraguay, Peru, Saint Kitts and Nevis, Saint Lucia,
-          Saint Vincent and the Grenadines, Suriname, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Sint Maarten, Suriname, Trinidad and Tobago,
           United States Virgin Islands, Uruguay, Venezuela
         ]
     - Other (R5):

--- a/definitions/region/common.yaml
+++ b/definitions/region/common.yaml
@@ -158,10 +158,10 @@
         navigate: R9LAM
         countries: [
           Antigua and Barbuda, Argentina, Aruba, Bahamas, Barbados, Belize,
-          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Dominican Republic,
+          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curaçao, Dominican Republic,
           Ecuador, El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala, Guyana,
           Haiti, Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama, Paraguay,
-          Peru, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines,
+          Peru, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines, Sint Maarten,
           Suriname, Trinidad and Tobago, United States Virgin Islands, Uruguay, Venezuela
         ]
     - Other (R9):
@@ -216,11 +216,11 @@
         ar6: R10LATIN_AM
         countries: [
           Antigua and Barbuda, Argentina, Aruba, Bahamas, Barbados, Belize,
-          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Dominican Republic, Ecuador,
+          Bolivia, Brazil, Chile, Colombia, Costa Rica, Cuba, Curaçao, Dominican Republic, Ecuador,
           El Salvador, French Guiana, Grenada, Guadeloupe, Guatemala, Guyana, Haiti,
           Honduras, Jamaica, Martinique, Mexico, Nicaragua, Panama, Paraguay, Peru,
           Puerto Rico, Saint Kitts and Nevis, Saint Lucia,
-          Saint Vincent and the Grenadines, Suriname, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Sint Maarten, Suriname, Trinidad and Tobago,
           United States Virgin Islands, Uruguay, Venezuela
         ]
     - Middle East (R10):


### PR DESCRIPTION
Add two countries that in 2010, like Aruba in 1986, separated from the Netherlands to become a constituent country inside the Kingdom of the Netherlands

For more, see https://en.wikipedia.org/wiki/Kingdom_of_the_Netherlands 


This is a small PR, but points to larger questions (which could be transferred into a new Issue, i think): 
(a) when to add new countries to the mapping?
(b) is there a way to ensure that there is no overlap?
(c) is there a way to ensure completeness?
(d) should we force IAM mappings to be up-to-date with the latest common R5/R9/R10 mapping?


**How to review?**

- [ ] check if this would need to be added somewhere else
- [ ] check if this is in line with the geojson data
