### PR TITLE
Fix tiers of industry-production and price variables

### DIFF
--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -17,9 +17,10 @@
         tier: ^2
     - Industry|Non-Ferrous Metals|Other Metals:
         description: non-ferrous metals sector excluding aluminum and copper
+        tier: ^2
     - Industry|Non-Metallic Minerals:
-        tier: ^1
         description: non-metallic minerals sector
+        tier: ^1
     - Industry|Non-Metallic Minerals|Cement:
         description: cement sector
         tier: ^1

--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -1,7 +1,7 @@
 - Price|Production|Iron and Steel|{Iron Commodity}:
     description: Price of {Iron Commodity}
     unit: USD_2010/Mt
-    tier: "{Iron Commodity}"
+    tier: 2
     weight: Production|Iron and Steel|{Iron Commodity}
     navigate: Price|Industry|Iron and Steel|{Iron Commodity}
     engage: Price|Industry|Iron and Steel|{Iron Commodity}
@@ -9,7 +9,7 @@
 - Price|Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}:
     description: Price of {Non-Metallic Minerals Commodity}
     unit: USD_2010/Mt
-    tier: "{Non-Metallic Minerals Commodity}"
+    tier: 2
     weight: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
     navigate: Price|Industry|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
     engage: Price|Industry|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
@@ -17,7 +17,7 @@
 - Price|Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
     description: Price of {Non-Ferrous Metals Commodity}
     unit: USD_2010/Mt
-    tier: "{Non-Ferrous Metals Commodity}"
+    tier: 2
     weight: Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
     navigate: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
     engage: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
@@ -25,7 +25,7 @@
 - Price|Production|Chemicals|{Chemicals Commodity}:
     description: Price of {Chemicals Commodity}
     unit: USD_2010/Mt
-    tier: "{Chemicals Commodity}"
+    tier: 2
     weight: Production|Chemicals|{Chemicals Commodity}
     navigate: Price|Industry|Chemicals|{Chemicals Commodity}
     engage: Price|Industry|Chemicals|{Chemicals Commodity}

--- a/definitions/variable/industry/production.yaml
+++ b/definitions/variable/industry/production.yaml
@@ -1,32 +1,32 @@
 - Production|Iron and Steel|{Iron Commodity}:
     description: Production of {Iron Commodity}
     unit: Mt/yr
-    tier: "{Iron Commodity}"
+    tier: 2
     navigate: Production|Iron and Steel|{Iron Commodity}|Volume
     engage: Production|Iron and Steel|{Iron Commodity}|Volume
 
 - Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}:
     description: Production of {Non-Metallic Minerals Commodity}
     unit: Mt/yr
-    tier: "{Non-Metallic Minerals Commodity}"
+    tier: 2
     navigate: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
     engage: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
 
 - Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
     description: Production of {Non-Ferrous Metals Commodity}
     unit: Mt/yr
-    tier: "{Non-Ferrous Metals Commodity}"
+    tier: 2
     navigate: Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}|Volume
     engage: Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}|Volume
 
 - Production|Chemicals|{Chemicals Commodity}:
     description: Production of {Chemicals Commodity}
     unit: Mt/yr
-    tier: "{Chemicals Commodity}"
+    tier: 2
     navigate: Production|Chemicals|{Chemicals Commodity}|Volume
     engage: Production|Chemicals|{Chemicals Commodity}|Volume
 
 - Production|Pulp and Paper|{Pulp and Paper Commodity}:
     description: Production of {Pulp and Paper Commodity}
     unit: Mt/yr
-    tier: "{Pulp and Paper Commodity}"
+    tier: 2

--- a/definitions/variable/industry/tag_chemical_commodities.yaml
+++ b/definitions/variable/industry/tag_chemical_commodities.yaml
@@ -1,46 +1,42 @@
 - Chemicals Commodity:
     - Ammonia:
         description: ammonia (NH3), precursor chemical for nitrogen fertilisers
-        tier: "1"
     - Nitrogen Fertilizer:
         description: single-nutrient nitrogen fertilizers and nitrogen containing
           multi-nutrient fertilizers
-        tier: "2"
+        tier: ^1
     - High-Value Chemicals:
         description: high-value chemicals, a group of primary chemicals consisting of
           ethylene, propylene, butylenes and aromatics
-        tier: "1"
         navigate: High Value Chemicals
         engage: High Value Chemicals
     - High-Value Chemicals|Ethylene:
         description: ethylene, most important precursor for synthetic plastics
-        tier: "2"
+        tier: ^1
     - High-Value Chemicals|Propylene:
         description: propylene, second most important precursor for synthetic plastics
-        tier: "2"
+        tier: ^1
     - High-Value Chemicals|BTX:
         description: the aromatic compounds Benzene, Toluene and the three xylene isomers (BTX)
-        tier: "2"
+        tier: ^1
     - Plastics:
         description: plastics
-        tier: "1"
     - Plastics|Primary:
         description: plastics, produced from virgin feedstocks
-        tier: "2"
+        tier: ^1
         navigate: Plastics|Primary Plastics
         engage: Plastics|Primary Plastics
     - Plastics|Secondary:
         description: plastics, produced in recycling processes
-        tier: "2"
+        tier: ^1
         navigate: Plastics|Secondary Plastics
         engage: Plastics|Secondary Plastics
     - Methanol:
         description: methanol, used as precursor for various chemicals and fuels
-        tier: "1"
     - Formaldehyde:
         description: formaldehyde, mainly used to produce resins
-        tier: "3"
+        tier: ^1
     - Formaldehyde Resins:
         description: thermosetting resins, produced by polymerizing urea, phenol and/or
           melamine with formaldehyde
-        tier: "3"
+        tier: ^1

--- a/definitions/variable/industry/tag_iron_commodities.yaml
+++ b/definitions/variable/industry/tag_iron_commodities.yaml
@@ -1,32 +1,31 @@
 - Iron Commodity:
     - Steel:
         description: raw steel, an alloy of carbon and iron
-        tier: "1"
     - Steel|Primary:
         description: raw steel, an alloy of carbon and iron, extracted from minerals
           and free of reclaimed metal scrap
-        tier: "2"
+        tier: ^1
         navigate: Primary Steel
         engage: Primary Steel
     - Steel|Secondary:
         description: raw steel, an alloy of carbon and iron, that does not directly
           originate from a primary mineral but from a recycling process or from the
-            processing of waste streams from primary production
-        tier: "2"
+          processing of waste streams from primary production
+        tier: ^1
         navigate: Secondary Steel
         engage: Secondary Steel
     - Iron:
         description: raw iron, used in the iron industry for the production of steel
-        tier: "2"
+        tier: ^1
     - Iron|Pig Iron:
         description: pig iron, an intermediate good used in the iron industry for the
           production of steel produced by smelting iron in a blast furnace
-        tier: "3"
+        tier: ^2
         navigate: Pig Iron
     - Iron|Sponge Iron:
         description: sponge iron (also called direct reduced iron)
-        tier: "3"
+        tier: ^2
         navigate: Sponge Iron
     - Iron Ore:
         description: ores, from which metallic iron can be economically extracted
-        tier: "2"
+        tier: ^1

--- a/definitions/variable/industry/tag_non-ferrous_commodities.yaml
+++ b/definitions/variable/industry/tag_non-ferrous_commodities.yaml
@@ -1,58 +1,57 @@
 - Non-Ferrous Metals Commodity:
     - Aluminum:
         description: aluminum
-        tier: "2"
         engage: Aluminium
         navigate: Aluminium
     - Aluminum|Primary:
         description: aluminum produced by electrolysis of alumina
-        tier: "3"
+        tier: ^1
         engage: Aluminium|Primary
         navigate: Aluminium|Primary
     - Aluminum|Secondary:
         description: aluminum produced by re-melting of scrap or that originates from a
           recycling process, including processing of waste streams from primary production
-        tier: "3"
+        tier: ^1
         engage: Aluminium|Secondary
         navigate: Aluminium|Secondary
     - Aluminum Oxide:
         description: aluminum oxide (alumina), commonly produced via the Bayer process
           from bauxite
-        tier: "3"
+        tier: ^1
         navigate: Alumina
         engage: Alumina
     - Bauxite:
         description: sedimentary rock with a relatively high aluminium content, main
           source of aluminium and gallium
-        tier: "3"
+        tier: ^1
     - Copper:
         description: copper
-        tier: "2"
+        tier: ^1
     - Copper|Primary:
         description: copper extracted from minerals and free of reclaimed metal scrap
-        tier: "3"
+        tier: ^2
     - Copper|Secondary:
         description: copper that does not directly originate from a primary mineral
           but from a recycling process or from the processing of waste streams from
           primary production
-        tier: "3"
+        tier: ^2
     - Lithium:
         description: lithium
-        tier: "2"
+        tier: ^1
     - Lithium|Primary:
         description: lithium extracted from minerals and free of reclaimed metal scrap
-        tier: "3"
+        tier: ^1
     - Lithium|Secondary:
         description: lithium that does not directly originate from a primary mineral
           but from a recycling process or from the processing of waste streams from
           primary production
-        tier: "3"
+        tier: ^1
     - Nickel:
         description: nickel
-        tier: "2"
+        tier: ^1
     - Graphite:
         description: graphite
-        tier: "2"
+        tier: ^1
     - Manganese:
         description: manganese
-        tier: "2"
+        tier: ^1

--- a/definitions/variable/industry/tag_non_metallic_commodities.yaml
+++ b/definitions/variable/industry/tag_non_metallic_commodities.yaml
@@ -1,19 +1,17 @@
 - Non-Metallic Minerals Commodity:
     - Cement:
         description: cement, a binder substance used for construction
-        tier: "1"
     - Cement Clinker:
         description: cement clinker, produced in the manufacture of portland cement as
-            an intermediary product
-        tier: "1"
+          an intermediary product
         navigate: Clinker
         engage: Clinker
     - Limestone:
         description: limestone
-        tier: "2"
+        tier: ^1
     - Glass:
         description: glass
-        tier: "3"
+        tier: ^2
     - Bricks:
         description: bricks, made from clay
-        tier: "3"
+        tier: ^2

--- a/definitions/variable/industry/tag_paper_commodities.yaml
+++ b/definitions/variable/industry/tag_paper_commodities.yaml
@@ -2,7 +2,5 @@
     - Pulp:
         description: pulp, produced from pulpwood, mainly used for paper, board,
           textiles and cellophane
-        tier: "2"
     - Paper:
         description: paper, thin sheet material made from cellulose fibers
-        tier: "2"


### PR DESCRIPTION
This PR adapts the industrial-sector production and price variable to use the new tier-implementation, so that all tiers are kept as integer in the DataStructureDefinition and not as strings.

FYI @IAMconsortium/common-definitions-industry 

Also closes #258 reported by @klau506