### PR TITLE
Add note on bunker emissions.

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -11,6 +11,9 @@
     tier: 1
     notes: Net emissions 'Emissions|CO2' = 'Gross Emissions|CO2' + 'Gross Removals|CO2'.
       For a breakdown of carbon removals, see the 'Carbon Removal|*' variables.
+      Emissions from bunker fuels used in international aviation and international shipping
+      are not included in national or regional totals, but should be included in global
+      totals.
     components:
       - Emissions|{Level-1 Species}|AFOLU
       - Emissions|{Level-1 Species}|Energy


### PR DESCRIPTION
In line with [IPCC 2006 reporting guidance](https://www.ipcc-nggip.iges.or.jp/public/2019rf/pdf/1_Volume1/19R_V1_Ch08_Reporting_Guidance.pdf): 

"The summary tables also allow reporting of memo items including international bunkers and multilateral
operations. These emissions are not included in national total emissions of greenhouse gases."
