### PR TITLE
Varaible From National scenario template

### DIFF
--- a/definitions/variable/macro-economy/gdp.yaml
+++ b/definitions/variable/macro-economy/gdp.yaml
@@ -6,6 +6,10 @@
     description: GDP converted to USD using purchasing power parity (PPP)
     unit: billion USD_2010/yr
     tier: 1
+- Value Added:
+    description: Total value added
+    unit: billion USD_2010/yr
+    tier: 1
 - Value Added|{Economic Sectors}:
     description: Value added by the {Economic Sectors}
     unit: billion USD_2010/yr

--- a/definitions/variable/macro-economy/macroeconomic_other.yaml
+++ b/definitions/variable/macro-economy/macroeconomic_other.yaml
@@ -7,7 +7,7 @@
 - Capital Stock:
     description: Macroeconomic capital stock
     unit: billion USD_2010/yr
-    tier: 1
+    tier: 2
 - Revenue|Government:
     description: Government revenue
     unit: billion USD_2010/yr
@@ -17,8 +17,8 @@
 - Debt:
     description: Total net external debt
     unit: billion USD_2010/yr
-    tier: 1
+    tier: 2
 - Debt|Public:
     description: Total net external public debt
     unit: billion USD_2010/yr
-    tier: 1
+    tier: 2

--- a/definitions/variable/macro-economy/macroeconomic_other.yaml
+++ b/definitions/variable/macro-economy/macroeconomic_other.yaml
@@ -7,9 +7,18 @@
 - Capital Stock:
     description: Macroeconomic capital stock
     unit: billion USD_2010/yr
+    tier: 1
 - Revenue|Government:
     description: Government revenue
     unit: billion USD_2010/yr
     tier: 1
     engage: Revenue|government
     navigate: Revenue|government
+- Debt:
+    description: Total net external debt
+    unit: billion USD_2010/yr
+    tier: 1
+- Debt|Public:
+    description: Total net external public debt
+    unit: billion USD_2010/yr
+    tier: 1


### PR DESCRIPTION
I went through the national scenario template to see what needed to be imported (double check welcomed).
 [https://data.ene.iiasa.ac.at/ar6-scenario-submission/static/files/national.zip](https://data.ene.iiasa.ac.at/ar6-scenario-submission/static/files/national.zip)

- Mostly Debt variables
- I found Investment|Clean Energy not well defined, which seems to be a sub-category of Investment|Energy Supply so I leave it behind
- Public Consumption is redundant with Expenditure|Government, which is a better name, so I leave it behind
- Labour Supply is defined under "Labor Force" now
- remaining: Subsidies, Taxes, Trade variables which should come in a dedicated PR

