### PR TITLE
Consumption and Income variables - proper redifinition of COICOP categories

### DIFF
--- a/definitions/variable/macro-economy/consumption.yaml
+++ b/definitions/variable/macro-economy/consumption.yaml
@@ -1,5 +1,22 @@
 - Consumption:
-    description: total consumption of all goods, by all consumers in a region
+    description: Total consumption of all goods, by all consumers in a region
     unit: billion USD_2010/yr
     tier: 1
     lower_bound: 0
+- Consumption|{Population Deciles} [Share]:
+    description: Share of total consumption accruing to the {Population Deciles}
+    unit: %
+    tier: 2
+    higher_bound: 100
+    lower_bound: 0
+    navigate: Consumption|{Population Deciles}
+    engage: Consumption|{Population Deciles}
+- Consumption|{COICP}|{Population Deciles} [Share]:
+    description: Share of total consumption of {COICP}, for the {Population Deciles}
+    unit: %
+    tier: 2
+    higher_bound: 100
+    lower_bound: 0
+    skip-region-aggregation: true
+    navigate: Consumption Share|{COICP}|{Population Deciles}
+    engage: Consumption Share|{COICP}|{Population Deciles}

--- a/definitions/variable/macro-economy/income.yaml
+++ b/definitions/variable/macro-economy/income.yaml
@@ -1,0 +1,8 @@
+- Income|{Population Deciles} [Share]:
+    description: Share of net income of the {Population Deciles} decile in total income
+    unit: %
+    tier: 2
+    higher_bound: 100
+    lower_bound: 0
+    navigate: Income|{Population Deciles}
+    engage: Income|{Population Deciles}

--- a/definitions/variable/macro-economy/tag_coicop.yaml
+++ b/definitions/variable/macro-economy/tag_coicop.yaml
@@ -1,0 +1,13 @@
+# Classification of individual Consumption According to Purpose (COICOP) 
+# https://unstats.un.org/unsd/classifications/unsdclassifications/COICOP_2018_-_pre-edited_white_cover_version_-_2018-12-26.pdf
+- COICOP:
+    - Food:
+        description: food and non-alcoholic beverages
+    - Housing|Energy:
+        description: electricity, gas and other fuels in housing (code 04.5)
+        navigate: Energy|Energy Use
+        engage: Energy|Energy Use
+    - Transport|Energy: 
+        description: fuels for personal transport equipment (Diesel: 07.2.2.1; Petrol: 07.2.2.3; Other fuels: 07.2.2.4)
+        navigate: Energy|Transportation
+        engage: Energy|Transportation

--- a/definitions/variable/macro-economy/tag_population_deciles.yaml
+++ b/definitions/variable/macro-economy/tag_population_deciles.yaml
@@ -1,0 +1,21 @@
+- Population Deciles:
+    - D1:
+        description: first Decile
+    - D2:
+        description: second Decile
+    - D3:
+        description: third Decile
+    - D4:
+        description: fourth Decile
+    - D5:
+        description: fifth Decile
+    - D6:
+        description: sixth Decile
+    - D7:
+        description: seventh Decile
+    - D8:
+        description: eighth Decile
+    - D9:
+        description: ninth Decile
+    - D10:
+        description: tenth Decile


### PR DESCRIPTION
Hi all,
Here comes Income and Consumption variables.
I build on navigate / engage, with some improved renaming and correct definition of consumption categories based on COICOP.

Discarded (engage/navigate - can be computed from the database):
# Consumption|Private|% change from Ref
# Consumption|Private|% change per GDP
# Consumption|Public|% change from Ref
# Consumption|Private|% change per GDP

