### PR TITLE
Add region definition and mapping for "MESSAGEix-GLOBIOM-GAINS 2.1-R12"

### DIFF
--- a/definitions/region/native_regions/MESSAGEix-GLOBIOM-GAINS_2.1-R12.yaml
+++ b/definitions/region/native_regions/MESSAGEix-GLOBIOM-GAINS_2.1-R12.yaml
@@ -1,0 +1,77 @@
+- MESSAGEix-GLOBIOM-GAINS 2.1-R12:
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Sub-Saharan Africa:
+        countries: [
+          Angola, Benin, Congo, Democratic Republic of the Congo, Burundi, Cameroon,
+          Chad, Comoros, Central African Republic, Cabo Verde, Djibouti,
+          Equatorial Guinea, Eswatini, Eritrea, Ethiopia, Gambia, Gabon, Ghana, Guinea, Côte d'Ivoire,
+          Kenya, Liberia, Madagascar, Mali, Mauritius, Mauritania, Mozambique, Malawi,
+          Niger, Nigeria, Guinea-Bissau, Rwanda, Seychelles, South Africa, Lesotho,
+          Botswana, Senegal, Sierra Leone, Somalia, Togo, Sao Tome and Principe,
+          Tanzania, Uganda, Burkina Faso, Namibia, Zambia, Zimbabwe, Western Sahara
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Rest of Centrally Planned Asia:
+        countries: [
+          Cambodia, North Korea, Laos, Mongolia, Macao, Viet Nam
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|China:
+        countries: [ China, Hong Kong ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Eastern Europe:
+        countries: [
+          Albania, Bosnia and Herzegovina, Bulgaria, Estonia, Czechia, Croatia,
+          Hungary, Latvia, Lithuania, Slovakia, North Macedonia, Montenegro,
+          Poland, Romania, Slovenia, Serbia
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Former Soviet Union:
+        countries: [
+          Azerbaijan, Armenia, Georgia, Kyrgyzstan, Kazakhstan, Belarus, Moldova,
+          Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Latin America and the Caribbean:
+        countries: [
+          Antigua and Barbuda, Argentina, Barbados, Bermuda, Bahamas, Belize, Bolivia,
+          Brazil, Chile, Cayman Islands, Colombia, Costa Rica, Cuba, Dominica,
+          Dominican Republic, Ecuador, El Salvador, French Guiana, Falkland Islands (Malvinas),
+          Grenada, Guatemala, Guyana, Haiti, Honduras, Jamaica, Martinique, Montserrat,
+          Mexico, Aruba, Anguilla, Suriname, Nicaragua, Paraguay, Peru, Panama,
+          Saint Kitts and Nevis, Saint Lucia, Trinidad and Tobago, Uruguay,
+          Saint Vincent and the Grenadines, Venezuela, Guadeloupe, Turks and Caicos Islands
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Middle East and North Africa:
+        countries: [
+          Algeria, Bahrain, Egypt, Iran, Israel, Iraq, Jordan, Kuwait, Lebanon, Libya,
+          Morocco, Oman, Palestine, Qatar, Saudi Arabia, Sudan, South Sudan, Syria,
+          Tunisia, Yemen, United Arab Emirates
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|North America:
+        countries: [
+          Canada, Guam, United States Minor Outlying Islands, Puerto Rico, United States,
+          United States Virgin Islands
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Pacific OECD:
+        countries: [
+          Australia, Japan, New Zealand, Christmas Island,
+          Heard Island and McDonald Islands, Tokelau
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Other Pacific Asia:
+        countries: [
+          American Samoa, Myanmar, Solomon Islands, Brunei Darussalam, Cook Islands, Fiji,
+          Micronesia, French Polynesia, Kiribati, South Korea, Malaysia, New Caledonia,
+          Niue, Northern Mariana Islands, Cocos (Keeling) Islands, Vanuatu, Nauru,
+          Papua New Guinea, Philippines, Singapore, Thailand, Tonga, Tuvalu, Samoa,
+          Indonesia, Timor-Leste, Palau, Marshall Islands, Taiwan
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|South Asia:
+        countries: [
+          Bangladesh, Sri Lanka, Afghanistan, Bhutan, India, Maldives, Nepal, Pakistan
+        ]
+    - MESSAGEix-GLOBIOM-GAINS 2.1-R12|Western Europe:
+        countries: [
+          Cyprus, Denmark, Ireland, Austria, Finland, France, Greenland, Germany, Greece,
+          Iceland, Italy, Liechtenstein, Malta, Belgium, Faroe Islands, Andorra,
+          Gibraltar, Isle of Man, Luxembourg, Monaco, Mayotte, Åland Islands,
+          Norfolk Island, British Indian Ocean Territory, Netherlands, Norway, Portugal,
+          Réunion, Spain, Sweden, Switzerland, Turkey, United Kingdom,
+          British Virgin Islands, Wallis and Futuna, Pitcairn, Saint Pierre and Miquelon,
+          San Marino, Vatican, Svalbard and Jan Mayen, Saint Martin (French part),
+          Saint Barthélemy, Guernsey, Jersey, South Georgia and the South Sandwich Islands
+        ]

--- a/mappings/MESSAGEix-GLOBIOM-GAINS_2.1-M-R12.yaml
+++ b/mappings/MESSAGEix-GLOBIOM-GAINS_2.1-M-R12.yaml
@@ -1,0 +1,74 @@
+model:
+  - MESSAGEix-GLOBIOM-GAINS 2.1-M-R12
+
+native_regions:
+  - R12_AFR: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Sub-Saharan Africa
+  - R12_RCPA: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Rest of Centrally Planned Asia
+  - R12_CHN: MESSAGEix-GLOBIOM-GAINS 2.1-R12|China
+  - R12_EEU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Eastern Europe
+  - R12_FSU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Former Soviet Union
+  - R12_LAM: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Latin America and the Caribbean
+  - R12_MEA: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Middle East and North Africa
+  - R12_NAM: MESSAGEix-GLOBIOM-GAINS 2.1-R12|North America
+  - R12_PAO: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Pacific OECD
+  - R12_PAS: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Other Pacific Asia
+  - R12_SAS: MESSAGEix-GLOBIOM-GAINS 2.1-R12|South Asia
+  - R12_WEU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Western Europe
+
+common_regions:
+  - World:
+      - R12_AFR
+      - R12_RCPA
+      - R12_CHN
+      - R12_EEU
+      - R12_FSU
+      - R12_LAM
+      - R12_MEA
+      - R12_NAM
+      - R12_PAO
+      - R12_PAS
+      - R12_SAS
+      - R12_WEU
+
+  # R5 regions
+  - Asia (R5):
+      - R12_SAS
+      - R12_PAS
+      - R12_RCPA
+      - R12_CHN
+  - Latin America (R5):
+      - R12_LAM
+  - Middle East & Africa (R5):
+      - R12_MEA
+      - R12_AFR
+  - OECD & EU (R5):
+      - R12_WEU
+      - R12_PAO
+      - R12_NAM
+      - R12_EEU
+  - Reforming Economies (R5):
+      - R12_FSU
+
+  # R10 regions
+  - Africa (R10):
+      - R12_AFR
+  - China+ (R10):
+      - R12_CHN
+      - R12_RCPA
+  - Europe (R10):
+      - R12_EEU
+      - R12_WEU
+  - India+ (R10):
+      - R12_SAS
+  - Latin America (R10):
+      - R12_LAM
+  - Middle East (R10):
+      - R12_MEA
+  - North America (R10):
+      - R12_NAM
+  - Pacific OECD (R10):
+      - R12_PAO
+  - Reforming Economies (R10):
+      - R12_FSU
+  - Rest of Asia (R10):
+      - R12_PAS


### PR DESCRIPTION
This PR adds a new model-region-group "MESSAGEix-GLOBIOM-GAINS 2.1-R12" and the mapping for the "M"-variant of that model.