### PR TITLE
Units: add consistency in t DM units

### DIFF
--- a/definitions/variable/afolu/tag_forestry-semi-finished.yaml
+++ b/definitions/variable/afolu/tag_forestry-semi-finished.yaml
@@ -13,7 +13,7 @@
         unit: million m3/yr
     - Mechanical Pulp:
         description: mechanical pulp
-        unit: million tDM/yr
+        unit: million t DM/yr
     - Chemical Pulp:
         description: chemical pulp
-        unit: million tDM/yr
+        unit: million t DM/yr

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -315,7 +315,7 @@
     shape: Material recycling|{Recycled Materials}|Share
 - Agricultural Material Footprint [per capita]:
     description: Biomass usage per capita excluding pasture and forestry
-    unit: tDM/cap/yr
+    unit: t DM/cap/yr
     sdg: 12
     weight: Population
     shape: Agricultural Material Footprint


### PR DESCRIPTION
Standardize the notation for `t DM` units to ensure consistency, as both `tDM` and `t DM` were previously used.






