### PR TITLE
improved definition for Agricultural Demand|Crops|Food

### DIFF
--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -38,7 +38,7 @@
     agmip:
     tier: 3
 - Agricultural Demand|Crops|Food:
-    description: Demand for food crops
+    description: Demand for food crops (primary and processed)
     unit: million t DM/yr
     agmip: Food demand (FOOD) - Crops (CRP)
     tier: 2


### PR DESCRIPTION
`Agricultural Demand|Crops|Food` should include demand for food crops from primary products (e.g. rice) and processed products (e.g. oil -> soybean)