### PR TITLE
Skip region aggregate for income-share-by-decile variable

### DIFF
--- a/definitions/variable/macro-economy/income.yaml
+++ b/definitions/variable/macro-economy/income.yaml
@@ -3,5 +3,6 @@
     unit: '%'
     tier: 2
     range: [ 0, 100 ]
+    skip-region-aggregation: true
     navigate: Income|{Population Deciles}
     engage: Income|{Population Deciles}


### PR DESCRIPTION
I noticed this missing specification when validating ScenarioMIP submissions.