### PR TITLE
Adding variable definitions for Residential and Commercial sectors

### DIFF
--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -1,11 +1,11 @@
 - Energy Service|Residential|{Urban and Rural}|Appliance Onwership|{Appliances}:
-    description: Onwership of {Appliances} per household
+    description: Onwership of appliances per household and appliance category
     unit: units/dwelling
     tier: 3
 
 - Energy Service|Residential|{Urban and Rural}|Heating and Cooling|{Heating and Cooling Technologies}:
-    description: Households with {Heating and Cooling Technologies} as primary
-      heating and cooling source
+    description: Households with specific heating and cooling technologies} 
+        as primary heating and cooling source
     unit: dwellings
     tier: 2
 
@@ -15,7 +15,8 @@
     tier: 2
 
 - Energy Service|{Residential and Commercial}|Zero Energy Building:
-    description: Residential and commercial buildings which have net-zero or positive energy balance 
+    description: Residential and commercial buildings which have net-zero or 
+        positive energy balance 
     unit: buildings
     tier: 2
 
@@ -26,6 +27,7 @@
 
 
 - Population|Appliance Access|{Appliances}|{Urban and Rural}:
-    description: Population with steady access to {Appliances} appliances
+    description: Population with steady access to appliances per appliance
+        category
     unit: million
     tier: 2

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -35,7 +35,13 @@
     unit: households
     tier: 2
 
-- Population|Appliance Access|{Appliances}|{Urban and Rural}:
+- Population|Appliance Access|{Appliance group}|{Urban and Rural}:
+    description: Population with steady access to appliances per appliance
+        category
+    unit: million
+    tier: 2
+
+- Population|Appliance Access|{Appliance}|{Urban and Rural}:
     description: Population with steady access to appliances per appliance
         category
     unit: million

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -1,28 +1,33 @@
-- Energy Service|Residential|{Urban and Rural}|Appliance Onwership|{Appliances}:
-    description: Onwership of appliances per household and appliance category
-    unit: units/dwelling
+- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliances}:
+    description: Ownership of appliances per household and appliance category
+    unit: units/household
     tier: 3
 
 - Energy Service|Residential|{Urban and Rural}|Heating and Cooling|{Heating and Cooling Technologies}:
     description: Households with specific heating and cooling technologies 
         as primary heating and cooling source
-    unit: dwellings
+    unit: million households
+    tier: 2
+
+- Energy Service|{Residential and Commercial}|Rooftop Photovoltaics:
+    description: Residential and commercial buildings with rooftop photovoltaic electricity generation
+    unit: million households
     tier: 2
 
 - Energy Service|Residential|{Urban and Rural}|Rooftop Photovoltaics:
-    description: Households with rooftop photovoltaic electricity generations
-    unit: dwellings
+    description: Households with rooftop photovoltaic electricity generation
+    unit: million households
     tier: 2
 
 - Energy Service|{Residential and Commercial}|Zero Energy Building:
     description: Residential and commercial buildings which have net-zero or 
         positive energy balance 
-    unit: buildings
+    unit: million buildings or households
     tier: 2
 
 - Energy Service|Residential|{Urban and Rural}|Zero Energy Building:
     description: Households which have net-zero or positive energy balance 
-    unit: dwellings
+    unit: households
     tier: 2
 
 

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -1,5 +1,15 @@
-- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliances}:
-    description: Ownership of appliances per household and appliance category
+- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliance group}:
+    description: Ownership of appliances per household and appliance group
+    unit: units/household
+    tier: 3
+
+- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliance}:
+    description: Ownership of appliances per household and appliance 
+    unit: units/household
+    tier: 3
+
+- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliance group}:
+    description: Ownership of appliances per household and appliance group
     unit: units/household
     tier: 3
 
@@ -29,7 +39,6 @@
     description: Households which have net-zero or positive energy balance 
     unit: households
     tier: 2
-
 
 - Population|Appliance Access|{Appliances}|{Urban and Rural}:
     description: Population with steady access to appliances per appliance

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -4,7 +4,7 @@
     tier: 3
 
 - Energy Service|Residential|{Urban and Rural}|Heating and Cooling|{Heating and Cooling Technologies}:
-    description: Households with specific heating and cooling technologies} 
+    description: Households with specific heating and cooling technologies 
         as primary heating and cooling source
     unit: dwellings
     tier: 2

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -1,0 +1,31 @@
+- Energy Service|Residential|{Urban and Rural}|Appliance Onwership|{Appliances}:
+    description: Onwership of {Appliances} per household
+    unit: units/dwelling
+    tier: 3
+
+- Energy Service|Residential|{Urban and Rural}|Heating and Cooling|{Heating and Cooling Technologies}:
+    description: Households with {Heating and Cooling Technologies} as primary
+      heating and cooling source
+    unit: dwellings
+    tier: 2
+
+- Energy Service|Residential|{Urban and Rural}|Rooftop Photovoltaics:
+    description: Households with rooftop photovoltaic electricity generations
+    unit: dwellings
+    tier: 2
+
+- Energy Service|{Residential and Commercial}|Zero Energy Building:
+    description: Residential and commercial buildings which have net-zero or positive energy balance 
+    unit: buildings
+    tier: 2
+
+- Energy Service|Residential|{Urban and Rural}|Zero Energy Building:
+    description: Households which have net-zero or positive energy balance 
+    unit: dwellings
+    tier: 2
+
+
+- Population|Appliance Access|{Appliances}|{Urban and Rural}:
+    description: Population with steady access to {Appliances} appliances
+    unit: million
+    tier: 2

--- a/definitions/variable/buildings/energy-services.yaml
+++ b/definitions/variable/buildings/energy-services.yaml
@@ -8,11 +8,6 @@
     unit: units/household
     tier: 3
 
-- Energy Service|Residential|{Urban and Rural}|Appliance Ownership|{Appliance group}:
-    description: Ownership of appliances per household and appliance group
-    unit: units/household
-    tier: 3
-
 - Energy Service|Residential|{Urban and Rural}|Heating and Cooling|{Heating and Cooling Technologies}:
     description: Households with specific heating and cooling technologies 
         as primary heating and cooling source

--- a/definitions/variable/buildings/service.yaml
+++ b/definitions/variable/buildings/service.yaml
@@ -1,5 +1,0 @@
-- Energy Service|{Residential & Commercial}|Floor Space:
-    description: Energy service demand for conditioned floor space
-      in {Residential & Commercial} buildings
-    unit: billion m2
-    tier: 2

--- a/definitions/variable/buildings/stocks.yaml
+++ b/definitions/variable/buildings/stocks.yaml
@@ -1,40 +1,40 @@
-- Stocks|{Residential and Commercial}|Floor Space:
-    description: Stocks of floor space
+- Building Stock|{Residential and Commercial}|Floor Space|{useful vs. gross}:
+    description: Standing stock of floor space
       in residential and commercial buildings
     unit: billion m2
     tier: 2
 
-- Stocks|Residential|{Urban and Rural}|Floor Space:
-    description: Stocks of floor space
-      in Residential buildings per urban/rural demographics
+- Building Stock|Residential|{Urban and Rural}|Floor Space|{useful vs. gross}:
+    description: Standing stock of floor space
+      in Residential buildings, for urban and rural residential buildings
     unit: billion m2
     tier: 2
 
-- Stocks|Residential|{Urban and Rural}|Floor Space|{Residential Building Type}:
-    description: Stocks of floor space in Residential (Urban and Rural)
+- Building Stock|Residential|{Urban and Rural}|Floor Space|{Residential Building Type}|{useful vs. gross}:
+    description: Standing stock of floor space in residential (urban and rural)
       buildings and residential building type
     unit: billion m2
     tier: 2
 
-- Stocks|{Residential and Commercial}|Renovation Rate:
-    description: Percetnage of residential and commercial buildings undergoing 
+- Building Stock|{Residential and Commercial}|Renovation Rate:
+    description: Percentage of residential and commercial buildings undergoing 
       renovation
-    unit: '%'
+    unit: '%/yr'
     tier: 2
 
-- Stocks|Residential|{Urban and Rural}|Renovation Rate:
-    description: Percetnage of urban and rural residential buildings 
-      undergoing renovation
-    unit: '%'
+- Building Stock|Residential|{Urban and Rural}|Renovation Rate:
+    description: Percentage of urban and rural residential buildings 
+      undergoing renovation, for urban and rural residential buildings
+    unit: '%/yr'
     tier: 2
 
-- Stocks|{Residential and Commercial}|U-value:
+- Building Stock|{Residential and Commercial}|U-value:
     description: Thermal conductivity of outer building shell, as a measure of
-      thermal energy efficiency, for commercial buildings
+      thermal energy efficiency
     unit: W/m^2/K
     tier: 2
 
-- Stocks|Residential|{Urban and Rural}|U-value:
+- Building Stock|Residential|{Urban and Rural}|U-value:
     description: Thermal conductivity of outer building shell, as a measure of
       thermal energy efficiency, for urban and rural residential buildings
     unit: W/m^2/K

--- a/definitions/variable/buildings/stocks.yaml
+++ b/definitions/variable/buildings/stocks.yaml
@@ -1,6 +1,6 @@
 - Stocks|{Residential and Commercial}|Floor Space:
     description: Stocks of floor space
-      in {Residential & Commercial} buildings
+      in residential and commercial buildings
     unit: billion m2
     tier: 2
 
@@ -11,19 +11,19 @@
     tier: 2
 
 - Stocks|Residential|{Urban and Rural}|Floor Space|{Residential Building Type}:
-    description: Stocks of floor space in Residential {Urban and Rural} 
-      buildings and {Residential Building Type}
+    description: Stocks of floor space in Residential (Urban and Rural)
+      buildings and residential building type
     unit: billion m2
     tier: 2
 
 - Stocks|{Residential and Commercial}|Renovation Rate:
-    description: Percetnage of {Residential & Commercial} buildings undergoing 
+    description: Percetnage of residential and commercial buildings undergoing 
       renovation
     unit: '%'
     tier: 2
 
 - Stocks|Residential|{Urban and Rural}|Renovation Rate:
-    description: Percetnage of residential {Urban and Rural} buildings 
+    description: Percetnage of urban and rural residential buildings 
       undergoing renovation
     unit: '%'
     tier: 2
@@ -36,6 +36,6 @@
 
 - Stocks|Residential|{Urban and Rural}|U-value:
     description: Thermal conductivity of outer building shell, as a measure of
-      thermal energy efficiency, for {Urban and Rural} residential buildings
+      thermal energy efficiency, for urban and rural residential buildings
     unit: W/m^2/K
     tier: 2

--- a/definitions/variable/buildings/stocks.yaml
+++ b/definitions/variable/buildings/stocks.yaml
@@ -12,7 +12,13 @@
 
 - Building Stock|Residential|{Urban and Rural}|Floor Space|{Residential Building Type}|{useful vs. gross}:
     description: Standing stock of floor space in residential (urban and rural)
-      buildings and residential building type
+      buildings and residential building type (i.e. singly or multi family buildings)
+    unit: billion m2
+    tier: 2
+
+- Building Stock|Residential|{Urban and Rural}|Floor Space|{Residential Unit Type}|{useful vs. gross}:
+    description: Standing stock of floor space in residential (urban and rural)
+      buildings and residential unit type
     unit: billion m2
     tier: 2
 

--- a/definitions/variable/buildings/stocks.yaml
+++ b/definitions/variable/buildings/stocks.yaml
@@ -1,0 +1,41 @@
+- Stocks|{Residential and Commercial}|Floor Space:
+    description: Stocks of floor space
+      in {Residential & Commercial} buildings
+    unit: billion m2
+    tier: 2
+
+- Stocks|Residential|{Urban and Rural}|Floor Space:
+    description: Stocks of floor space
+      in Residential buildings per urban/rural demographics
+    unit: billion m2
+    tier: 2
+
+- Stocks|Residential|{Urban and Rural}|Floor Space|{Residential Building Type}:
+    description: Stocks of floor space in Residential {Urban and Rural} 
+      buildings and {Residential Building Type}
+    unit: billion m2
+    tier: 2
+
+- Stocks|{Residential and Commercial}|Renovation Rate:
+    description: Percetnage of {Residential & Commercial} buildings undergoing 
+      renovation
+    unit: %
+    tier: 2
+
+- Stocks|Residential|{Urban and Rural}|Renovation Rate:
+    description: Percetnage of residential {Urban and Rural} buildings 
+      undergoing renovation
+    unit: %
+    tier: 2
+
+- Stocks|{Residential and Commercial}|U-value:
+    description: Thermal conductivity of outer building shell, as a measure of
+      thermal energy efficiency, for commercial buildings
+    unit: W/m^2/K
+    tier: 2
+
+- Stocks|Residential|{Urban and Rural}|U-value:
+    description: Thermal conductivity of outer building shell, as a measure of
+      thermal energy efficiency, for {Urban and Rural} residential buildings
+    unit: W/m^2/K
+    tier: 2

--- a/definitions/variable/buildings/stocks.yaml
+++ b/definitions/variable/buildings/stocks.yaml
@@ -19,13 +19,13 @@
 - Stocks|{Residential and Commercial}|Renovation Rate:
     description: Percetnage of {Residential & Commercial} buildings undergoing 
       renovation
-    unit: %
+    unit: '%'
     tier: 2
 
 - Stocks|Residential|{Urban and Rural}|Renovation Rate:
     description: Percetnage of residential {Urban and Rural} buildings 
       undergoing renovation
-    unit: %
+    unit: '%'
     tier: 2
 
 - Stocks|{Residential and Commercial}|U-value:

--- a/definitions/variable/buildings/tag_appliances.yaml
+++ b/definitions/variable/buildings/tag_appliances.yaml
@@ -1,0 +1,18 @@
+- Appliances:
+    - Cleaning:
+        description: Appliances used for cleaning, including vaccuum cleaners,
+            dish washers, washing machines, clothes dryers, etc.
+    - Cooling:
+        description: Appliances used for space cooling, including air coolers,
+            air conditioners, fans, etc.
+    - Entertainment:
+        description: Appliances used for entertainment, including air coolers,
+            televisions, computers, gaming, etc.
+    - Refrigeration:
+        description: Appliances used for food refregeration and preservation,
+            including refrigerators, freezers, etc.
+    - Other:
+        description: Appliances used in housseholds not falling under the other
+         categories
+
+

--- a/definitions/variable/buildings/tag_appliances.yaml
+++ b/definitions/variable/buildings/tag_appliances.yaml
@@ -6,8 +6,8 @@
         description: Appliances used for space cooling, including air coolers,
             air conditioners, fans, etc.
     - Entertainment:
-        description: Appliances used for entertainment, including air coolers,
-            televisions, computers, gaming, etc.
+        description: Appliances used for entertainment, including televisions, 
+            computers, gaming, etc.
     - Refrigeration:
         description: Appliances used for food refregeration and preservation,
             including refrigerators, freezers, etc.

--- a/definitions/variable/buildings/tag_appliances.yaml
+++ b/definitions/variable/buildings/tag_appliances.yaml
@@ -1,4 +1,4 @@
-- Appliances:
+- Appliance group:
     - Cleaning:
         description: Appliances used for cleaning, including vaccuum cleaners,
             dish washers, washing machines, clothes dryers, etc.
@@ -15,4 +15,17 @@
         description: Appliances used in housseholds not falling under the other
          categories
 
-
+- Appliance:
+    - Cleaning|Dish washer:
+        description: Dishwashers
+    - Cleaning|Washing machine:
+        description: Washing machine for clothes and fabrics
+    - Cleaning|Clothes dryer:
+        description: Clothes dryers
+    - Cooling|Air cooler:
+        description: Evaporative air coolers
+    - Cooling|Air conditioner:
+        description: Air conditioners and temperature control ventilation systems
+    - Cooling|fan:
+        description: Fans and small ventilation systems without temperature control
+    

--- a/definitions/variable/buildings/tag_appliances.yaml
+++ b/definitions/variable/buildings/tag_appliances.yaml
@@ -26,6 +26,6 @@
         description: Evaporative air coolers
     - Cooling|Air conditioner:
         description: Air conditioners and temperature control ventilation systems
-    - Cooling|fan:
+    - Cooling|Fan:
         description: Fans and small ventilation systems without temperature control
     

--- a/definitions/variable/buildings/tag_heating_and_cooling_technologies.yaml
+++ b/definitions/variable/buildings/tag_heating_and_cooling_technologies.yaml
@@ -1,0 +1,15 @@
+- Heating and Cooling Technologies:
+    - Air Conditioning:
+        description: Centralized or standalone air conditioning units
+    - Air Cooler:
+        description: Air coolers, evaporative or other
+    - Fan:
+        description: Fans, including cieling, tower, or standalone
+    - Electric Heater:
+        description: Electric heaters (i.e. resistance)
+    - Heat Pump:
+        description: Heatpumps, including air or ground-sourced
+    - District Heating:
+        description: District heating providing secondary heat
+
+

--- a/definitions/variable/buildings/tag_residential_building_type.yaml
+++ b/definitions/variable/buildings/tag_residential_building_type.yaml
@@ -4,15 +4,15 @@
             (i.e. detached houses)
     - Multi Family Housing:
         description: Residential building that houses multiple families 
-            (i.e. semi-detached, appartments, etc.)
+            (i.e. semi-detached, apartments, etc.)
     - Slum:
         description: Informal households of mixed type
 
 - Residential Unit Type:
     - Single Family Housing|Detached:
         description: Detached households
-    - Multi Family Housing|Appartment:
-        description: Appartment households
+    - Multi Family Housing|Apartment:
+        description: Apartment households
     - Multi Family Housing|High-rise:
         description: High-rise households
     - Multi Family Housing|Semi-detached:

--- a/definitions/variable/buildings/tag_residential_building_type.yaml
+++ b/definitions/variable/buildings/tag_residential_building_type.yaml
@@ -1,13 +1,19 @@
 - Residential Building Type:
-    - Appartment:
-        description: Appartment households
-    - Detached:
-        description: Detached households
-    - High-rise:
-        description: High-rise households
-    - Semi-detached:
-        description: Semi-detached households
+    - Single Family Housing:
+        description: Residential building that houses a single family 
+            (i.e. detached houses)
+    - Multi Family Housing:
+        description: Residential building that houses multiple families 
+            (i.e. semi-detached, appartments, etc.)
     - Slum:
-        description: Slum households
+        description: Informal households of mixed type
 
-
+- Residential Unit Type:
+    - Single Family Housing|Detached:
+        description: Detached households
+    - Multi Family Housing|Appartment:
+        description: Appartment households
+    - Multi Family Housing|High-rise:
+        description: High-rise households
+    - Multi Family Housing|Semi-detached:
+        description: Semi-detached households

--- a/definitions/variable/buildings/tag_residential_building_type.yaml
+++ b/definitions/variable/buildings/tag_residential_building_type.yaml
@@ -1,0 +1,13 @@
+- Residential Building Type:
+    - Appartment:
+        description: Appartment households
+    - Detached:
+        description: Detached households
+    - High-rise:
+        description: High-rise households
+    - Semi-detached:
+        description: Semi-detached households
+    - Slum:
+        description: Slum households
+
+

--- a/definitions/variable/buildings/tag_residential_commercial.yaml
+++ b/definitions/variable/buildings/tag_residential_commercial.yaml
@@ -1,4 +1,4 @@
-- Residential & Commercial:
+- Residential and Commercial:
     - Residential:
         description: residential
     - Commercial:

--- a/definitions/variable/buildings/tag_urban_rural.yaml
+++ b/definitions/variable/buildings/tag_urban_rural.yaml
@@ -1,0 +1,7 @@
+- Urban and Rural:
+    - Urban:
+        description: Urban households
+    - Rural:
+        description: Rural households
+    - Total:
+        description: All houeholds

--- a/definitions/variable/buildings/tag_useful_vs_gross.yaml
+++ b/definitions/variable/buildings/tag_useful_vs_gross.yaml
@@ -1,0 +1,7 @@
+- useful vs. gross:
+    - Useful:
+        description: Useful floorspace (i.e. floosrpace that is heated and used 
+          directly)
+    - Gross:
+        description: Gross floorspace (i.e. useful floosrpace plus unused floosrpace
+          stocks)

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -54,10 +54,67 @@
         tier: ^1
     - Residential:
         description: residential sector
+        tier: ^1
+    - Residential|Appliances:
+        description: residential sector appliances
+        tier: 2
+    - Residential|Cooking:
+        description: residential sector cooking
+        tier: 2
+    - Residential|Lighting:
+        description: residential sector lighting
+        tier: 2
+    - Residential|Space Cooling:
+        description: residential sector space cooling
+        tier: 2
+    - Residential|Space Heating:
+        description: residential sector space heating
+        tier: 2
+    - Residential|Water Heating:
+        description: residential sector space heating
+        tier: 2
     - Commercial:
         description: commercial sector
+        tier: ^1
+    - Commercial|Appliances:
+        description: commercial sector appliances
+        tier: 2
+    - Commercial|Cooking:
+        description: commercial sector cooking
+        tier: 2
+    - Commercial|Lighting:
+        description: commercial sector lighting
+        tier: 2
+    - Commercial|Space Cooling:
+        description: commercial sector space cooling
+        tier: 2
+    - Commercial|Space Heating:
+        description: commercial sector space heating
+        tier: 2
+    - Commercial|Water Heating:
+        description: commercial sector space heating
+        tier: 2
     - Residential and Commercial:
         description: residential and commercial sector
+        tier: ^1
+    - Residential and Commercial|Appliances:
+        description: residential and commercial sector appliances
+        tier: 2
+    - Residential and Commercial|Cooking:
+        description: residential and commercial sector cooking
+        tier: 2
+    - Residential and Commercial|Lighting:
+        description: residential and commercial sector lighting
+        tier: 2
+    - Residential and Commercial|Space Cooling:
+        description: residential and commercial sector space cooling
+        tier: 2
+    - Residential and Commercial|Space Heating:
+        description: residential and commercial sector space heating
+        tier: 2
+    - Residential and Commercial|Water Heating:
+        description: residential and commercial sector space heating
+        tier: 2
     - Transportation:
         description: transportation sector excluding international aviation and shipping
           (see 'Bunkers')

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -57,64 +57,64 @@
         tier: ^1
     - Residential|Appliances:
         description: residential sector appliances
-        tier: 2
+        tier: ^2
     - Residential|Cooking:
         description: residential sector cooking
-        tier: 2
+        tier: ^2
     - Residential|Lighting:
         description: residential sector lighting
-        tier: 2
+        tier: ^2
     - Residential|Space Cooling:
         description: residential sector space cooling
-        tier: 2
+        tier: ^2
     - Residential|Space Heating:
         description: residential sector space heating
-        tier: 2
+        tier: ^2
     - Residential|Water Heating:
         description: residential sector space heating
-        tier: 2
+        tier: ^2
     - Commercial:
         description: commercial sector
         tier: ^1
     - Commercial|Appliances:
         description: commercial sector appliances
-        tier: 2
+        tier: ^2
     - Commercial|Cooking:
         description: commercial sector cooking
-        tier: 2
+        tier: ^2
     - Commercial|Lighting:
         description: commercial sector lighting
-        tier: 2
+        tier: ^2
     - Commercial|Space Cooling:
         description: commercial sector space cooling
-        tier: 2
+        tier: ^2
     - Commercial|Space Heating:
         description: commercial sector space heating
-        tier: 2
+        tier: ^2
     - Commercial|Water Heating:
         description: commercial sector space heating
-        tier: 2
+        tier: ^2
     - Residential and Commercial:
         description: residential and commercial sector
         tier: ^1
     - Residential and Commercial|Appliances:
         description: residential and commercial sector appliances
-        tier: 2
+        tier: ^2
     - Residential and Commercial|Cooking:
         description: residential and commercial sector cooking
-        tier: 2
+        tier: ^2
     - Residential and Commercial|Lighting:
         description: residential and commercial sector lighting
-        tier: 2
+        tier: ^2
     - Residential and Commercial|Space Cooling:
         description: residential and commercial sector space cooling
-        tier: 2
+        tier: ^2
     - Residential and Commercial|Space Heating:
         description: residential and commercial sector space heating
-        tier: 2
+        tier: ^2
     - Residential and Commercial|Water Heating:
         description: residential and commercial sector space heating
-        tier: 2
+        tier: ^2
     - Transportation:
         description: transportation sector excluding international aviation and shipping
           (see 'Bunkers')


### PR DESCRIPTION
This PR adds further variables for the residential and commercial sectors. Thi includes:
- Stock of floorspace, and buidling types
- Renovation rates and building U-values
- Access to different appliance groups and heating or cooling technologies
- Some variables for "prosumers", including use of rooftop PV, prevalence of net-zero buildings
- Energy demand per different building energy services (cooling, heating, etc.)

Had to add a number of tags differentiating between
- Urban and rural households
- Residential building types
- Appliances groups
- heating and cooling technologies
