### PR TITLE
Add region-definitions for legacy REMIND[-MAgPIE] versions

### DIFF
--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
@@ -1,0 +1,79 @@
+- REMIND-MAgPIE 3.2-4.6:
+    - REMIND-MAgPIE 3.2-4.6|Canada, Australia, New Zealand:
+        countries: [
+          Australia, Canada, Heard Island and McDonald Islands, New Zealand,
+          Saint Pierre and Miquelon
+        ]
+    - REMIND-MAgPIE 3.2-4.6|China and Taiwan:
+        countries: [ China, Hong Kong, Macao, Taiwan ]
+    - REMIND-MAgPIE 3.2-4.6|India:
+        countries: India
+    - REMIND-MAgPIE 3.2-4.6|Japan:
+        countries: Japan
+    - REMIND-MAgPIE 3.2-4.6|Other Asia:
+        countries: [
+          Afghanistan, American Samoa, Bangladesh, Bhutan,
+          British Indian Ocean Territory, Brunei Darussalam, Cambodia, Christmas Island,
+          Cocos (Keeling) Islands, Cook Islands, Fiji, French Polynesia,
+          French Southern Territories, Guam, Indonesia, Kiribati, Laos, Malaysia,
+          Maldives, Marshall Islands, Micronesia, Mongolia, Myanmar, Nauru, Nepal,
+          New Caledonia, Niue, Norfolk Island, North Korea, Northern Mariana Islands,
+          Pakistan, Palau, Papua New Guinea, Philippines, Pitcairn, Samoa, Singapore,
+          Solomon Islands, South Korea, Sri Lanka, Thailand, Timor-Leste, Tokelau,
+          Tonga, Tuvalu, United States Minor Outlying Islands, Vanuatu, Viet Nam,
+          Wallis and Futuna
+        ]
+    - REMIND-MAgPIE 3.2-4.6|Latin America and the Caribbean:
+        countries: [
+          Anguilla, Antarctica, Antigua and Barbuda, Argentina, Aruba, Bahamas,
+          Barbados, Belize, Bermuda, Bolivia, "Bonaire, Sint Eustatius and Saba",
+          Bouvet Island, Brazil, British Virgin Islands, Cayman Islands, Chile,
+          Colombia, Costa Rica, Cuba, Curaçao, Curaçao, Dominica, Dominican Republic,
+          Ecuador, El Salvador, Falkland Islands (Malvinas), French Guiana, Grenada,
+          Guadeloupe, Guatemala, Guyana, Haiti, Honduras,
+          Jamaica, Martinique, Mexico, Montserrat, Nicaragua, Panama, Paraguay, Peru,
+          Puerto Rico, Saint Barthélemy, Saint Kitts and Nevis, Saint Lucia,
+          Saint Martin (French part), Saint Vincent and the Grenadines,
+          Sint Maarten (Dutch part), South Georgia and the South Sandwich Islands,
+          Suriname, Trinidad and Tobago, Turks and Caicos Islands,
+          United States Virgin Islands, Uruguay, Venezuela
+        ]
+    - REMIND-MAgPIE 3.2-4.6|Middle East and North Africa:
+        countries: [
+          Algeria, Bahrain, Egypt, Iran, Iraq, Israel, Jordan, Kuwait, Lebanon,
+          Libya, Morocco, Oman, Palestine, Qatar, Saudi Arabia, Sudan, Syria,
+          Tunisia, United Arab Emirates, Western Sahara, Yemen
+        ]
+    - REMIND-MAgPIE 3.2-4.6|Russia and Reforming Economies:
+        countries: [
+          Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
+          Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
+        ]
+    - REMIND-MAgPIE 3.2-4.6|Sub-Saharan Africa:
+        countries: [
+          Angola, Benin, Botswana, Burkina Faso, Burundi, Cabo Verde, Cameroon,
+          Central African Republic, Chad, Comoros, Congo, Côte d'Ivoire,
+          Democratic Republic of the Congo, Djibouti, Equatorial Guinea,
+          Eritrea, Eswatini, Ethiopia, Gabon, Gambia, Ghana, Guinea,
+          Guinea-Bissau, Kenya, Lesotho, Liberia, Madagascar, Malawi, Mali,
+          Mauritania, Mauritius, Mayotte, Mozambique, Namibia, Niger, Nigeria,
+          Rwanda, Réunion, "Saint Helena, Ascension and Tristan da Cunha",
+          Sao Tome and Principe, Senegal, Seychelles, Sierra Leone, Somalia,
+          South Africa, South Sudan, Tanzania, Togo, Uganda, Zambia, Zimbabwe
+        ]
+    - REMIND-MAgPIE 3.2-4.6|United States of America:
+        countries: United States
+    - REMIND-MAgPIE 3.2-4.6|EU 28:
+        countries: [
+          Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
+          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
+          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
+          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
+          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+        ]
+    - REMIND-MAgPIE 3.2-4.6|Non-EU28 Europe:
+        countries: [
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
+          Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
+        ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
@@ -1,0 +1,79 @@
+- REMIND-MAgPIE 3.3-4.8:
+    - REMIND-MAgPIE 3.3-4.8|Canada, Australia, New Zealand:
+        countries: [
+          Australia, Canada, Heard Island and McDonald Islands, New Zealand,
+          Saint Pierre and Miquelon
+        ]
+    - REMIND-MAgPIE 3.3-4.8|China and Taiwan:
+        countries: [ China, Hong Kong, Macao, Taiwan ]
+    - REMIND-MAgPIE 3.3-4.8|India:
+        countries: India
+    - REMIND-MAgPIE 3.3-4.8|Japan:
+        countries: Japan
+    - REMIND-MAgPIE 3.3-4.8|Other Asia:
+        countries: [
+          Afghanistan, American Samoa, Bangladesh, Bhutan,
+          British Indian Ocean Territory, Brunei Darussalam, Cambodia, Christmas Island,
+          Cocos (Keeling) Islands, Cook Islands, Fiji, French Polynesia,
+          French Southern Territories, Guam, Indonesia, Kiribati, Laos, Malaysia,
+          Maldives, Marshall Islands, Micronesia, Mongolia, Myanmar, Nauru, Nepal,
+          New Caledonia, Niue, Norfolk Island, North Korea, Northern Mariana Islands,
+          Pakistan, Palau, Papua New Guinea, Philippines, Pitcairn, Samoa, Singapore,
+          Solomon Islands, South Korea, Sri Lanka, Thailand, Timor-Leste, Tokelau,
+          Tonga, Tuvalu, United States Minor Outlying Islands, Vanuatu, Viet Nam,
+          Wallis and Futuna
+        ]
+    - REMIND-MAgPIE 3.3-4.8|Latin America and the Caribbean:
+        countries: [
+          Anguilla, Antarctica, Antigua and Barbuda, Argentina, Aruba, Bahamas,
+          Barbados, Belize, Bermuda, Bolivia, "Bonaire, Sint Eustatius and Saba",
+          Bouvet Island, Brazil, British Virgin Islands, Cayman Islands, Chile,
+          Colombia, Costa Rica, Cuba, Curaçao, Curaçao, Dominica, Dominican Republic,
+          Ecuador, El Salvador, Falkland Islands (Malvinas), French Guiana, Grenada,
+          Guadeloupe, Guatemala, Guyana, Haiti, Honduras,
+          Jamaica, Martinique, Mexico, Montserrat, Nicaragua, Panama, Paraguay, Peru,
+          Puerto Rico, Saint Barthélemy, Saint Kitts and Nevis, Saint Lucia,
+          Saint Martin (French part), Saint Vincent and the Grenadines,
+          Sint Maarten (Dutch part), South Georgia and the South Sandwich Islands,
+          Suriname, Trinidad and Tobago, Turks and Caicos Islands,
+          United States Virgin Islands, Uruguay, Venezuela
+        ]
+    - REMIND-MAgPIE 3.3-4.8|Middle East and North Africa:
+        countries: [
+          Algeria, Bahrain, Egypt, Iran, Iraq, Israel, Jordan, Kuwait, Lebanon,
+          Libya, Morocco, Oman, Palestine, Qatar, Saudi Arabia, Sudan, Syria,
+          Tunisia, United Arab Emirates, Western Sahara, Yemen
+        ]
+    - REMIND-MAgPIE 3.3-4.8|Russia and Reforming Economies:
+        countries: [
+          Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
+          Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
+        ]
+    - REMIND-MAgPIE 3.3-4.8|Sub-Saharan Africa:
+        countries: [
+          Angola, Benin, Botswana, Burkina Faso, Burundi, Cabo Verde, Cameroon,
+          Central African Republic, Chad, Comoros, Congo, Côte d'Ivoire,
+          Democratic Republic of the Congo, Djibouti, Equatorial Guinea,
+          Eritrea, Eswatini, Ethiopia, Gabon, Gambia, Ghana, Guinea,
+          Guinea-Bissau, Kenya, Lesotho, Liberia, Madagascar, Malawi, Mali,
+          Mauritania, Mauritius, Mayotte, Mozambique, Namibia, Niger, Nigeria,
+          Rwanda, Réunion, "Saint Helena, Ascension and Tristan da Cunha",
+          Sao Tome and Principe, Senegal, Seychelles, Sierra Leone, Somalia,
+          South Africa, South Sudan, Tanzania, Togo, Uganda, Zambia, Zimbabwe
+        ]
+    - REMIND-MAgPIE 3.3-4.8|United States of America:
+        countries: United States
+    - REMIND-MAgPIE 3.3-4.8|EU 28:
+        countries: [
+          Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
+          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
+          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
+          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
+          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+        ]
+    - REMIND-MAgPIE 3.3-4.8|Non-EU28 Europe:
+        countries: [
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
+          Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
+        ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -1,0 +1,79 @@
+- REMIND 3.0:
+    - REMIND 3.0|Canada, Australia, New Zealand:
+        countries: [
+          Australia, Canada, Heard Island and McDonald Islands, New Zealand,
+          Saint Pierre and Miquelon
+        ]
+    - REMIND 3.0|China and Taiwan:
+        countries: [ China, Hong Kong, Macao, Taiwan ]
+    - REMIND 3.0|India:
+        countries: India
+    - REMIND 3.0|Japan:
+        countries: Japan
+    - REMIND 3.0|Other Asia:
+        countries: [
+          Afghanistan, American Samoa, Bangladesh, Bhutan,
+          British Indian Ocean Territory, Brunei Darussalam, Cambodia, Christmas Island,
+          Cocos (Keeling) Islands, Cook Islands, Fiji, French Polynesia,
+          French Southern Territories, Guam, Indonesia, Kiribati, Laos, Malaysia,
+          Maldives, Marshall Islands, Micronesia, Mongolia, Myanmar, Nauru, Nepal,
+          New Caledonia, Niue, Norfolk Island, North Korea, Northern Mariana Islands,
+          Pakistan, Palau, Papua New Guinea, Philippines, Pitcairn, Samoa, Singapore,
+          Solomon Islands, South Korea, Sri Lanka, Thailand, Timor-Leste, Tokelau,
+          Tonga, Tuvalu, United States Minor Outlying Islands, Vanuatu, Viet Nam,
+          Wallis and Futuna
+        ]
+    - REMIND 3.0|Latin America and the Caribbean:
+        countries: [
+          Anguilla, Antarctica, Antigua and Barbuda, Argentina, Aruba, Bahamas,
+          Barbados, Belize, Bermuda, Bolivia, "Bonaire, Sint Eustatius and Saba",
+          Bouvet Island, Brazil, British Virgin Islands, Cayman Islands, Chile,
+          Colombia, Costa Rica, Cuba, Curaçao, Curaçao, Dominica, Dominican Republic,
+          Ecuador, El Salvador, Falkland Islands (Malvinas), French Guiana, Grenada,
+          Guadeloupe, Guatemala, Guyana, Haiti, Honduras,
+          Jamaica, Martinique, Mexico, Montserrat, Nicaragua, Panama, Paraguay, Peru,
+          Puerto Rico, Saint Barthélemy, Saint Kitts and Nevis, Saint Lucia,
+          Saint Martin (French part), Saint Vincent and the Grenadines,
+          Sint Maarten (Dutch part), South Georgia and the South Sandwich Islands,
+          Suriname, Trinidad and Tobago, Turks and Caicos Islands,
+          United States Virgin Islands, Uruguay, Venezuela
+        ]
+    - REMIND 3.0|Middle East and North Africa:
+        countries: [
+          Algeria, Bahrain, Egypt, Iran, Iraq, Israel, Jordan, Kuwait, Lebanon,
+          Libya, Morocco, Oman, Palestine, Qatar, Saudi Arabia, Sudan, Syria,
+          Tunisia, United Arab Emirates, Western Sahara, Yemen
+        ]
+    - REMIND 3.0|Russia and Reforming Economies:
+        countries: [
+          Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Moldova,
+          Russian Federation, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
+        ]
+    - REMIND 3.0|Sub-Saharan Africa:
+        countries: [
+          Angola, Benin, Botswana, Burkina Faso, Burundi, Cabo Verde, Cameroon,
+          Central African Republic, Chad, Comoros, Congo, Côte d'Ivoire,
+          Democratic Republic of the Congo, Djibouti, Equatorial Guinea,
+          Eritrea, Eswatini, Ethiopia, Gabon, Gambia, Ghana, Guinea,
+          Guinea-Bissau, Kenya, Lesotho, Liberia, Madagascar, Malawi, Mali,
+          Mauritania, Mauritius, Mayotte, Mozambique, Namibia, Niger, Nigeria,
+          Rwanda, Réunion, "Saint Helena, Ascension and Tristan da Cunha",
+          Sao Tome and Principe, Senegal, Seychelles, Sierra Leone, Somalia,
+          South Africa, South Sudan, Tanzania, Togo, Uganda, Zambia, Zimbabwe
+        ]
+    - REMIND 3.0|United States of America:
+        countries: United States
+    - REMIND 3.0|EU 28:
+        countries: [
+          Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
+          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
+          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
+          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
+          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+        ]
+    - REMIND 3.0|Non-EU28 Europe:
+        countries: [
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
+          Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
+        ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -63,6 +63,7 @@
         ]
     - REMIND 3.0|United States of America:
         countries: United States
+    # 12-region version of REMIND
     - REMIND 3.0|EU 28:
         countries: [
           Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
@@ -76,4 +77,44 @@
           Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
+        ]
+    # 21-region version of REMIND
+    - REMIND 3.0|Germany:
+        countries: [ Germany ]
+    - REMIND 3.0|France:
+        countries: [ France ]
+    - REMIND 3.0|United Kingdom and Ireland:
+        countries: [
+          Gibraltar, Guernsey, Ireland, Isle of Man, Jersey, United Kingdom
+        ]
+    - REMIND 3.0|EU Center-East Europe:
+        countries: [ Czechia, Estonia, Latvia, Lithuania, Poland, Slovakia ]
+    - REMIND 3.0|EU Center-South Europe:
+        countries: [ Bulgaria, Croatia, Hungary, Romania, Slovenia ]
+    - REMIND 3.0|EU North-Center Europe:
+        countries: [ Denmark, Faroe Islands, Finland, Sweden, Åland Islands ]
+    - REMIND 3.0|EU South-Center Europe:
+        countries: [ Cyprus, Greece, Italy, Malta ]
+    - REMIND 3.0|EU South-West Europe:
+        countries: [ Portugal, Spain ]
+    - REMIND 3.0|EU North-West Europe:
+        countries: [ Austria, Belgium, Luxembourg, Netherlands ]
+    - REMIND 3.0|Non-EU Northern Europe:
+        countries: [
+          Greenland, Iceland, Liechtenstein, Norway, Svalbard and Jan Mayen,
+          Switzerland
+        ]
+    - REMIND 3.0|Non-EU Southern Europe:
+        countries: [
+          Albania, Andorra, Bosnia and Herzegovina, Monaco, Montenegro,
+          North Macedonia, San Marino, Serbia, Turkey, Vatican
+        ]
+    # exogenously aggregated regions
+    - REMIND 3.0|EU 27:
+        notes: This is an aggregation of the six EU-27 regions in REMIND 3.0
+        countries: [
+          Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
+          Faroe Islands, Finland, France, Germany, Greece, Hungary, Italy, Latvia,
+          Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
+          Slovakia, Slovenia, Spain, Sweden, Åland Islands
         ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -80,9 +80,9 @@
         ]
     # 21-region version of REMIND
     - REMIND 3.0|Germany:
-        countries: [ Germany ]
+        countries: Germany
     - REMIND 3.0|France:
-        countries: [ France ]
+        countries: France
     - REMIND 3.0|United Kingdom and Ireland:
         countries: [
           Gibraltar, Guernsey, Ireland, Isle of Man, Jersey, United Kingdom

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.1.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.1.yaml
@@ -7,9 +7,9 @@
     - REMIND 3.1|China and Taiwan:
         countries: [ China, Hong Kong, Macao, Taiwan ]
     - REMIND 3.1|India:
-        countries: [ India ]
+        countries: India
     - REMIND 3.1|Japan:
-        countries: [ Japan ]
+        countries: Japan
     - REMIND 3.1|Other Asia:
         countries: [
           Afghanistan, American Samoa, Bangladesh, Bhutan,
@@ -62,7 +62,7 @@
           South Africa, South Sudan, Tanzania, Togo, Uganda, Zambia, Zimbabwe
         ]
     - REMIND 3.1|United States of America:
-        countries: [ United States ]
+        countries: United States
     # 12-region version of REMIND
     - REMIND 3.1|EU 28:
         countries: [
@@ -80,9 +80,9 @@
         ]
     # 21-region version of REMIND
     - REMIND 3.1|Germany:
-        countries: [ Germany ]
+        countries: Germany
     - REMIND 3.1|France:
-        countries: [ France ]
+        countries: France
     - REMIND 3.1|United Kingdom and Ireland:
         countries: [
           Gibraltar, Guernsey, Ireland, Isle of Man, Jersey, United Kingdom

--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
@@ -1,0 +1,72 @@
+model: REMIND-MAgPIE 3.2-4.6
+
+native_regions:
+  - CAZ: REMIND-MAgPIE 3.2-4.6|Canada, Australia, New Zealand
+  - CHA: REMIND-MAgPIE 3.2-4.6|China and Taiwan
+  - IND: REMIND-MAgPIE 3.2-4.6|India
+  - JPN: REMIND-MAgPIE 3.2-4.6|Japan
+  - OAS: REMIND-MAgPIE 3.2-4.6|Other Asia
+  - LAM: REMIND-MAgPIE 3.2-4.6|Latin America and the Caribbean
+  - MEA: REMIND-MAgPIE 3.2-4.6|Middle East and North Africa
+  - REF: REMIND-MAgPIE 3.2-4.6|Russia and Reforming Economies
+  - SSA: REMIND-MAgPIE 3.2-4.6|Sub-Saharan Africa
+  - USA: REMIND-MAgPIE 3.2-4.6|United States of America
+  - EUR: REMIND-MAgPIE 3.2-4.6|EU 28
+  - NEU: REMIND-MAgPIE 3.2-4.6|Non-EU28 Europe
+
+common_regions:
+  - World:
+      - CAZ
+      - CHA
+      - IND
+      - JPN
+      - OAS
+      - LAM
+      - MEA
+      - REF
+      - SSA
+      - USA
+      - EUR
+      - NEU
+
+  - Asia (R5):
+      - CHA
+      - IND
+      - OAS
+  - Latin America (R5):
+      - LAM
+  - Middle East & Africa (R5):
+      - SSA
+      - MEA
+  - OECD & EU (R5):
+      - JPN
+      - USA
+      - CAZ
+      - EUR
+      - NEU
+  - Reforming Economies (R5):
+      - REF
+
+  - Africa (R10):
+      - SSA
+  - China+ (R10):
+      - CHA
+  - Europe (R10):
+      - EUR
+      - NEU
+  - India+ (R10):
+      - IND
+  - Latin America (R10):
+      - LAM
+  - Middle East (R10):
+      - MEA
+  - North America (R10):
+      - USA
+  - Reforming Economies (R10):
+      - REF
+  - Rest of Asia (R10):
+      - OAS
+  - Pacific OECD (R10):
+      - JPN
+  - Other (R10):
+      - CAZ

--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
@@ -1,0 +1,72 @@
+model: REMIND-MAgPIE 3.3-4.8
+
+native_regions:
+  - CAZ: REMIND-MAgPIE 3.3-4.8|Canada, Australia, New Zealand
+  - CHA: REMIND-MAgPIE 3.3-4.8|China and Taiwan
+  - IND: REMIND-MAgPIE 3.3-4.8|India
+  - JPN: REMIND-MAgPIE 3.3-4.8|Japan
+  - OAS: REMIND-MAgPIE 3.3-4.8|Other Asia
+  - LAM: REMIND-MAgPIE 3.3-4.8|Latin America and the Caribbean
+  - MEA: REMIND-MAgPIE 3.3-4.8|Middle East and North Africa
+  - REF: REMIND-MAgPIE 3.3-4.8|Russia and Reforming Economies
+  - SSA: REMIND-MAgPIE 3.3-4.8|Sub-Saharan Africa
+  - USA: REMIND-MAgPIE 3.3-4.8|United States of America
+  - EUR: REMIND-MAgPIE 3.3-4.8|EU 28
+  - NEU: REMIND-MAgPIE 3.3-4.8|Non-EU28 Europe
+
+common_regions:
+  - World:
+      - CAZ
+      - CHA
+      - IND
+      - JPN
+      - OAS
+      - LAM
+      - MEA
+      - REF
+      - SSA
+      - USA
+      - EUR
+      - NEU
+
+  - Asia (R5):
+      - CHA
+      - IND
+      - OAS
+  - Latin America (R5):
+      - LAM
+  - Middle East & Africa (R5):
+      - SSA
+      - MEA
+  - OECD & EU (R5):
+      - JPN
+      - USA
+      - CAZ
+      - EUR
+      - NEU
+  - Reforming Economies (R5):
+      - REF
+
+  - Africa (R10):
+      - SSA
+  - China+ (R10):
+      - CHA
+  - Europe (R10):
+      - EUR
+      - NEU
+  - India+ (R10):
+      - IND
+  - Latin America (R10):
+      - LAM
+  - Middle East (R10):
+      - MEA
+  - North America (R10):
+      - USA
+  - Reforming Economies (R10):
+      - REF
+  - Rest of Asia (R10):
+      - OAS
+  - Pacific OECD (R10):
+      - JPN
+  - Other (R10):
+      - CAZ

--- a/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -15,8 +15,21 @@ native_regions:
   - REF: REMIND 3.0|Russia and Reforming Economies
   - SSA: REMIND 3.0|Sub-Saharan Africa
   - USA: REMIND 3.0|United States of America
+  # 12-region version of REMIND
   - EUR: REMIND 3.0|EU 28
   - NEU: REMIND 3.0|Non-EU28 Europe
+  # 21-region version of REMIND
+  - DEU: REMIND 3.0|Germany
+  - FRA: REMIND 3.0|France
+  - UKI: REMIND 3.0|United Kingdom and Ireland
+  - ECE: REMIND 3.0|EU Center-East Europe
+  - ECS: REMIND 3.0|EU Center-South Europe
+  - ENC: REMIND 3.0|EU North-Center Europe
+  - ESC: REMIND 3.0|EU South-Center Europe
+  - ESW: REMIND 3.0|EU South-West Europe
+  - EWN: REMIND 3.0|EU North-West Europe
+  - NEN: REMIND 3.0|Non-EU Northern Europe
+  - NES: REMIND 3.0|Non-EU Southern Europe
 
 common_regions:
   - World:
@@ -30,8 +43,21 @@ common_regions:
       - REF
       - SSA
       - USA
+      # 12-region version of REMIND
       - EUR
       - NEU
+      # 21-region version of REMIND
+      - DEU
+      - FRA
+      - UKI
+      - ECE
+      - ECS
+      - ENC
+      - ESC
+      - ESW
+      - EWN
+      - NEN
+      - NES
 
   - Asia (R5):
       - CHA
@@ -46,8 +72,21 @@ common_regions:
       - JPN
       - USA
       - CAZ
+      # 12-region version of REMIND
       - EUR
       - NEU
+      # 21-region version of REMIND
+      - DEU
+      - FRA
+      - UKI
+      - ECE
+      - ENC
+      - ECS
+      - ESC
+      - ESW
+      - EWN
+      - NEN
+      - NES
   - Reforming Economies (R5):
       - REF
 
@@ -56,8 +95,21 @@ common_regions:
   - China+ (R10):
       - CHA
   - Europe (R10):
+      # 12-region version of REMIND
       - EUR
       - NEU
+      # 21-region version of REMIND
+      - DEU
+      - FRA
+      - UKI
+      - ECE
+      - ENC
+      - ECS
+      - ESC
+      - ESW
+      - EWN
+      - NEN
+      - NES
   - India+ (R10):
       - IND
   - Latin America (R10):

--- a/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -1,0 +1,76 @@
+# WARNING for REMIND reporting: only include results
+# either for the 12-region resolution (EUR and NEU) or for the 21-region resolution!
+# Otherwise, there will be double-counting during region-aggregation.
+
+model: REMIND 3.0
+
+native_regions:
+  - CAZ: REMIND 3.0|Canada, Australia, New Zealand
+  - CHA: REMIND 3.0|China and Taiwan
+  - IND: REMIND 3.0|India
+  - JPN: REMIND 3.0|Japan
+  - OAS: REMIND 3.0|Other Asia
+  - LAM: REMIND 3.0|Latin America and the Caribbean
+  - MEA: REMIND 3.0|Middle East and North Africa
+  - REF: REMIND 3.0|Russia and Reforming Economies
+  - SSA: REMIND 3.0|Sub-Saharan Africa
+  - USA: REMIND 3.0|United States of America
+  - EUR: REMIND 3.0|EU 28
+  - NEU: REMIND 3.0|Non-EU28 Europe
+
+common_regions:
+  - World:
+      - CAZ
+      - CHA
+      - IND
+      - JPN
+      - OAS
+      - LAM
+      - MEA
+      - REF
+      - SSA
+      - USA
+      - EUR
+      - NEU
+
+  - Asia (R5):
+      - CHA
+      - IND
+      - OAS
+  - Latin America (R5):
+      - LAM
+  - Middle East & Africa (R5):
+      - SSA
+      - MEA
+  - OECD & EU (R5):
+      - JPN
+      - USA
+      - CAZ
+      - EUR
+      - NEU
+  - Reforming Economies (R5):
+      - REF
+
+  - Africa (R10):
+      - SSA
+  - China+ (R10):
+      - CHA
+  - Europe (R10):
+      - EUR
+      - NEU
+  - India+ (R10):
+      - IND
+  - Latin America (R10):
+      - LAM
+  - Middle East (R10):
+      - MEA
+  - North America (R10):
+      - USA
+  - Reforming Economies (R10):
+      - REF
+  - Rest of Asia (R10):
+      - OAS
+  - Pacific OECD (R10):
+      - JPN
+  - Other (R10):
+      - CAZ


### PR DESCRIPTION
For completeness and automated downscaling for the Scenario Compass project (@fabiosferra), this PR adds region-definitions and legacy mappings of the 12-region version of previous REMIND versions used in earlier projects.