### PR TITLE
More specific definition of crop yields

### DIFF
--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -172,7 +172,7 @@
     weight: Land Cover|Cropland|{Crop Types}
     tier: 2
     notes: Yields in FAOSTAT are reported on wet matter basis for harvested cropland area
-- Yield|Harvested Cropland|{Crop Types}:
+- Yield|Cropland|{Crop Types} [Harvested Area]:
     description: Yield of {Crop Types}, calculated as production (dry matter) divided by harvested cropland area
     unit: t DM/ha/yr
     weight: Land Cover|Cropland|{Crop Types}

--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -167,10 +167,17 @@
 
 # Crop Yields
 - Yield|Cropland|{Crop Types}:
-    description: Yield of cropland with {Crop Types}
+    description: Yield of {Crop Types}, calculated as production (dry matter) divided by physical cropland area
     unit: t DM/ha/yr
     weight: Land Cover|Cropland|{Crop Types}
     tier: 2
+    notes: Yields in FAOSTAT are reported on wet matter basis for harvested cropland area
+- Yield|Cropland Harvested|{Crop Types}:
+    description: Yield of {Crop Types}, calculated as production (dry matter) divided by harvested cropland area
+    unit: t DM/ha/yr
+    weight: Land Cover|Cropland|{Crop Types}
+    tier: 2
+    notes: Yields in FAOSTAT are reported on wet matter basis for harvested cropland area
 
 # Agricultural Prices
 - Price|Agriculture|Food Products [Index]:

--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -172,7 +172,7 @@
     weight: Land Cover|Cropland|{Crop Types}
     tier: 2
     notes: Yields in FAOSTAT are reported on wet matter basis for harvested cropland area
-- Yield|Cropland Harvested|{Crop Types}:
+- Yield|Harvested Cropland|{Crop Types}:
     description: Yield of {Crop Types}, calculated as production (dry matter) divided by harvested cropland area
     unit: t DM/ha/yr
     weight: Land Cover|Cropland|{Crop Types}


### PR DESCRIPTION
Crop yields can be based on physical or harvested area.
This PR refines the definition of the existing `Yield|Cropland|{Crop Types}` variables (physical) and adds new variables for yield based on harvested area `Yield|Cropland Harvested|{Crop Types}`.