### PR TITLE
Cropland: add fallow land and agroforestry trees

### DIFF
--- a/definitions/variable/afolu/land-cover.yaml
+++ b/definitions/variable/afolu/land-cover.yaml
@@ -22,8 +22,20 @@
     unit: million ha
     agmip: Land Cover (LAND) - All crops (CRP)
     tier: 1
+    components:
+      - Land Cover|Cropland|{Crop Types}
+      - Land Cover|Cropland|Fallow
+      - Land Cover|Cropland|Trees
 - Land Cover|Cropland|{Crop Types}:
     description: Cropland for {Crop Types}
+    unit: million ha
+    tier: 2
+- Land Cover|Cropland|Fallow:
+    description: Fallow cropland
+    unit: million ha
+    tier: 2
+- Land Cover|Cropland|Trees:
+    description: Trees for agroforesty
     unit: million ha
     tier: 2
 - Land Cover|Cropland|Rainfed:


### PR DESCRIPTION
This PR adds sub-categories for fallow land and agroforestry trees to `Land Cover|Cropland|`