### PR TITLE
secondary products - per-capita availability and intake

### DIFF
--- a/definitions/variable/afolu/food-system.yaml
+++ b/definitions/variable/afolu/food-system.yaml
@@ -28,6 +28,12 @@
     sdg: 2
     weight: Population
     tier: 3
+- Food Availability|Secondary Products [per capita]:
+    description: Amount of secondary products (e.g. oils and sugar) available per capita for consumption
+    unit: kcal/cap/day
+    sdg: 2
+    weight: Population
+    tier: 2
 
 - Food Intake [per capita]:
     description: Amount of crops and livestock products consumed per capita
@@ -59,6 +65,12 @@
     sdg: 2
     weight: Population
     tier: 3
+- Food Intake|Secondary Products [per capita]:
+    description: Amount of secondary products (e.g. oils and sugar) consumed per capita
+    unit: kcal/cap/day
+    sdg: 2
+    weight: Population
+    tier: 2
 
 - Food Waste [per capita]:
     description: Amount of food (crops and livestock) per capita that is disposed and


### PR DESCRIPTION
Secondary products such as oils and sugar are currently missing in the per-capita food availability and intake variables. 
They are needed to reconcile differences in the top level variables reported by the differend modelling teams. 
This PR adss secondary products for per-capita availability and intake.