### PR TITLE
Add mapping from model-native regions to R9 for REMIND-MAgPIE and REMIND

### DIFF
--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
@@ -47,6 +47,28 @@ common_regions:
   - Reforming Economies (R5):
       - REF
 
+  - European Union (R9):
+      - EUR
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - JPN
+      - CAZ
+      - NEU
+  - China (R9):
+      - CHA
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - OAS
+  - Reforming Economies (R9):
+      - REF
+  - Middle East & Africa (R9):
+      - MEA
+      - SSA
+  - Latin America (R9):
+      - LAM
+
   - Africa (R10):
       - SSA
   - China+ (R10):

--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
@@ -47,6 +47,28 @@ common_regions:
   - Reforming Economies (R5):
       - REF
 
+  - European Union (R9):
+      - EUR
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - JPN
+      - CAZ
+      - NEU
+  - China (R9):
+      - CHA
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - OAS
+  - Reforming Economies (R9):
+      - REF
+  - Middle East & Africa (R9):
+      - MEA
+      - SSA
+  - Latin America (R9):
+      - LAM
+
   - Africa (R10):
       - SSA
   - China+ (R10):

--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.4-4.8.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.4-4.8.yaml
@@ -47,6 +47,28 @@ common_regions:
   - Reforming Economies (R5):
       - REF
 
+  - European Union (R9):
+      - EUR
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - JPN
+      - CAZ
+      - NEU
+  - China (R9):
+      - CHA
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - OAS
+  - Reforming Economies (R9):
+      - REF
+  - Middle East & Africa (R9):
+      - MEA
+      - SSA
+  - Latin America (R9):
+      - LAM
+
   - Africa (R10):
       - SSA
   - China+ (R10):

--- a/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
@@ -47,6 +47,28 @@ common_regions:
   - Reforming Economies (R5):
       - REF
 
+  - European Union (R9):
+      - EUR
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - JPN
+      - CAZ
+      - NEU
+  - China (R9):
+      - CHA
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - OAS
+  - Reforming Economies (R9):
+      - REF
+  - Middle East & Africa (R9):
+      - MEA
+      - SSA
+  - Latin America (R9):
+      - LAM
+
   - Africa (R10):
       - SSA
   - China+ (R10):

--- a/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -90,6 +90,43 @@ common_regions:
   - Reforming Economies (R5):
       - REF
 
+  - European Union (R9):
+      # 12-region version of REMIND
+      - EUR
+      # 21-region version of REMIND
+      - DEU
+      - FRA
+      - ECE
+      - ENC
+      - ECS
+      - ESC
+      - ESW
+      - EWN
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - JPN
+      - CAZ
+      # 12-region version of REMIND
+      - NEU
+      # 21-region version of REMIND
+      - UKI
+      - NEN
+      - NES
+  - China (R9):
+      - CHA
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - OAS
+  - Reforming Economies (R9):
+      - REF
+  - Middle East & Africa (R9):
+      - MEA
+      - SSA
+  - Latin America (R9):
+      - LAM
+
   - Africa (R10):
       - SSA
   - China+ (R10):

--- a/mappings/REMIND-MAgPIE/REMIND_3.1.yaml
+++ b/mappings/REMIND-MAgPIE/REMIND_3.1.yaml
@@ -92,6 +92,43 @@ common_regions:
   - Reforming Economies (R5):
     - REF
 
+  - European Union (R9):
+    # 12-region version of REMIND
+    - EUR
+    # 21-region version of REMIND
+    - DEU
+    - FRA
+    - ECE
+    - ENC
+    - ECS
+    - ESC
+    - ESW
+    - EWN
+  - USA (R9):
+    - USA
+  - Other OECD (R9):
+    - JPN
+    - CAZ
+    # 12-region version of REMIND
+    - NEU
+    # 21-region version of REMIND
+    - UKI
+    - NEN
+    - NES
+  - China (R9):
+    - CHA
+  - India (R9):
+    - IND
+  - Other Asia (R9):
+    - OAS
+  - Reforming Economies (R9):
+    - REF
+  - Middle East & Africa (R9):
+    - MEA
+    - SSA
+  - Latin America (R9):
+    - LAM
+
   - Africa (R10):
     - SSA
   - China+ (R10):


### PR DESCRIPTION
This PR adds mappings from model-native regions of REMIND and REMIND-MAgPIE to common regions R9.

Note that `European Union (R9)` reflects membership status as of 2023 (EU 27), but `EUR` in REMIND (12 regions) and REMIND-MAgPIE includes the United Kingdom (EU 28). In REMIND (21 regions), this can be partly improved by mapping UKI (United Kingdom and Ireland) to `Other OECD (R9)` (even though Ireland should be part of `European Union (R9)`).

As the description in `definitions/region/common.yaml` contains the note _"Depending on the spatial resolution, reporting by some models may differ from the current list of EU27 members (2023)."_, this nonetheless seems to be the best possible mapping to common regions R9.

@flohump, @strefler, @Renato-Rodrigues: Thanks for double-checking.