### PR TITLE
Move R10 mapping of Korea to China

### DIFF
--- a/mappings/COFFEE/COFFEE_1.6.yaml
+++ b/mappings/COFFEE/COFFEE_1.6.yaml
@@ -99,6 +99,7 @@ common_regions:
       - SF
   - China+ (R10):
       - CH
+      - KR
   - Europe (R10):
       - EU
       - XE
@@ -120,7 +121,6 @@ common_regions:
       - CP
       - RU
   - Rest of Asia (R10):
-      - KR
       - RA
 
   # G20 members


### PR DESCRIPTION
This PR applies the change in #257 (moving Korea to "China (R10)") for COFFEE 1.5 also to COFFEE 1.6.

Please confirm @lbbaptista!

FYI @jkikstra 