### PR TITLE
Add Kosovo to REMIND native-region definitions

### DIFF
--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
@@ -66,10 +66,10 @@
     - REMIND-MAgPIE 3.2-4.6|EU 28:
         countries: [
           Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
-          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
-          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
-          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
-          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+          Faroe Islands, Finland, France, Germany, Gibraltar, Greece, Guernsey, Hungary,
+          Ireland, Isle of Man, Italy, Jersey, Latvia, Lithuania, Luxembourg, Malta,
+          Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden,
+          United Kingdom, Åland Islands
         ]
     - REMIND-MAgPIE 3.2-4.6|Non-EU28 Europe:
         countries: [

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.2-4.6.yaml
@@ -73,7 +73,7 @@
         ]
     - REMIND-MAgPIE 3.2-4.6|Non-EU28 Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland, Kosovo,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
         ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
@@ -66,10 +66,10 @@
     - REMIND-MAgPIE 3.3-4.8|EU 28:
         countries: [
           Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
-          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
-          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
-          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
-          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+          Faroe Islands, Finland, France, Germany, Gibraltar, Greece, Guernsey, Hungary,
+          Ireland, Isle of Man, Italy, Jersey, Latvia, Lithuania, Luxembourg, Malta,
+          Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden,
+          United Kingdom, Åland Islands
         ]
     - REMIND-MAgPIE 3.3-4.8|Non-EU28 Europe:
         countries: [

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.3-4.8.yaml
@@ -73,7 +73,7 @@
         ]
     - REMIND-MAgPIE 3.3-4.8|Non-EU28 Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland, Kosovo,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
         ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.4-4.8.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.4-4.8.yaml
@@ -66,10 +66,10 @@
     - REMIND-MAgPIE 3.4-4.8|EU 28:
         countries: [
           Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
-          Faroe Islands, Finland, France, Germany, Gibraltar, Greece,
-          Guernsey, Hungary, Ireland, Isle of Man, Italy, Jersey,
-          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
-          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+          Faroe Islands, Finland, France, Germany, Gibraltar, Greece, Guernsey, Hungary,
+          Ireland, Isle of Man, Italy, Jersey, Latvia, Lithuania, Luxembourg, Malta,
+          Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden,
+          United Kingdom, Åland Islands
         ]
     - REMIND-MAgPIE 3.4-4.8|Non-EU28 Europe:
         countries: [

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
@@ -66,10 +66,10 @@
     - REMIND-MAgPIE 3.5-4.10|EU 28:
         countries: [
           Austria, Belgium, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia,
-          Faroe Islands, Finland, France, Germany, Gibraltar, Gibraltar, Greece,
-          Guernsey, Guernsey, Hungary, Ireland, Isle of Man, Italy, Italy, Jersey,
-          Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania,
-          Slovakia, Slovenia, Spain, Sweden, United Kingdom, Åland Islands
+          Faroe Islands, Finland, France, Germany, Gibraltar, Greece, Guernsey, Hungary,
+          Ireland, Isle of Man, Italy, Jersey, Latvia, Lithuania, Luxembourg, Malta,
+          Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden,
+          United Kingdom, Åland Islands
         ]
     - REMIND-MAgPIE 3.5-4.10|Non-EU28 Europe:
         countries: [

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND-MAgPIE_3.5-4.10.yaml
@@ -73,7 +73,7 @@
         ]
     - REMIND-MAgPIE 3.5-4.10|Non-EU28 Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland, Kosovo,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
         ]

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.0.yaml
@@ -74,7 +74,7 @@
         ]
     - REMIND 3.0|Non-EU28 Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland, Kosovo,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
         ]
@@ -106,7 +106,7 @@
         ]
     - REMIND 3.0|Non-EU Southern Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Monaco, Montenegro,
+          Albania, Andorra, Bosnia and Herzegovina, Kosovo, Monaco, Montenegro,
           North Macedonia, San Marino, Serbia, Turkey, Vatican
         ]
     # exogenously aggregated regions

--- a/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.1.yaml
+++ b/definitions/region/native_regions/REMIND-MAgPIE/REMIND_3.1.yaml
@@ -74,7 +74,7 @@
         ]
     - REMIND 3.1|Non-EU28 Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland,
+          Albania, Andorra, Bosnia and Herzegovina, Greenland, Iceland, Kosovo,
           Liechtenstein, Monaco, Montenegro, North Macedonia, Norway, San Marino,
           Serbia, Svalbard and Jan Mayen, Switzerland, Turkey, Vatican
         ]
@@ -106,7 +106,7 @@
         ]
     - REMIND 3.1|Non-EU Southern Europe:
         countries: [
-          Albania, Andorra, Bosnia and Herzegovina, Monaco, Montenegro,
+          Albania, Andorra, Bosnia and Herzegovina, Kosovo, Monaco, Montenegro,
           North Macedonia, San Marino, Serbia, Turkey, Vatican
         ]
     # exogenously aggregated regions


### PR DESCRIPTION
This PR applies the fix by @jkikstra in #266 - adding Kosovo to the native-region definitions - to the other native-region definitions of the REMIND model.