### PR TITLE
Added variable mappings for old projects.

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -343,6 +343,10 @@
     description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
     unit: Mt CO2/yr
     tier: 2
+    # Only if `Non-Energy Sector` == "Iron and Steel"
+    navigate: Emissions|CO2|Energy|Demand|Industry|Steel
+    ngfs5: Emissions|CO2|Energy|Demand|Industry|Steel
+    shape: Emissions|CO2|Energy|Demand|Industry|Steel
 - Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial and AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in residential,
       commercial and institutional sectors (IPCC category 1A4a and 1A4b)
@@ -426,11 +430,17 @@
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Non-Energy Sector}
     unit: "{Level-3 Species}"
     tier: 2
+    navigate: Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}
+    # Only if `Non-Energy Sector` == "Iron and Steel"
+    ngfs5: Emissions|{Level-3 Species}|Steel
+    shape: Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}
 - Emissions|{Level-3 Species}|Industrial Processes|{Industrial-Process Sector}:
     description: Emissions of {Level-3 Species} from industrial processes
       (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Industrial-Process Sector}
     unit: "{Level-3 Species}"
     tier: 2
+    # Only when `Industrial-Process Sector` == "Cement"
+    navigate: Emissions|{Level-3 Species}|Industrial Processes|Non-Metallic Minerals|Cement
 
 - Emissions|{Level-3 Species}|Product Use:
     description: Emissions of {Level-3 Species} from product use (IPCC category 2D, 2F

--- a/definitions/variable/energy/final-energy.yaml
+++ b/definitions/variable/energy/final-energy.yaml
@@ -82,6 +82,8 @@
     description: Final energy consumption by the {Sector}
     unit: EJ/yr
     tier: 1
+    # Only when `Sector` == "Industry|Iron and Steel"
+    ngfs_phase_5: Final Energy|Industry|Steel
 - Final Energy|{Sector}|Electricity:
     description: Final energy consumption by the {Sector} of electricity
     unit: EJ/yr
@@ -90,6 +92,8 @@
     description: Final energy consumption by the {Sector} of {Secondary Fuel Level 2}
     unit: EJ/yr
     tier: 1
+    # Only when `Sector` == "Industry|Iron and Steel" and `Secondary Fuel Level 2` == "Solids|Coal"
+    ngfs_phase_5: Final Energy|Industry|Steel|Solids|Fossil
 - Final Energy|{Sector}|Other:
     description: Final energy consumption by the {Sector} of other energy sources
     unit: EJ/yr

--- a/definitions/variable/industry/production.yaml
+++ b/definitions/variable/industry/production.yaml
@@ -10,6 +10,7 @@
     navigate: Production|Iron and Steel|{Iron Commodity}|Volume
     engage: Production|Iron and Steel|{Iron Commodity}|Volume
     ngfs5: Production|{Iron Commodity}
+    shape: Production|{Iron Commodity}
 
 - Production|Non-Metallic Minerals:
     description: Production of Non-Metallic Minerals
@@ -23,6 +24,8 @@
     navigate: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
     engage: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
     ngfs5: Production|{Non-Metallic Minerals Commodity}
+    # Is this needed? The variable seems to be already imported successfully.
+    shape: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
 
 - Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
     description: Production of {Non-Ferrous Metals Commodity}

--- a/definitions/variable/transport/energy-services.yaml
+++ b/definitions/variable/transport/energy-services.yaml
@@ -2,13 +2,21 @@
     description: Energy service demand for passenger transport on roads in light duty vehicles
     unit: billion pkm/yr
     tier: 2
-    navigate: Energy Service|Transportation|Road|LDV
+    navigate: Energy Service|Transportation|Passenger|Road|LDV
+    ngfs5: Energy Service|Transportation|Passenger|Road|LDV
+    shape: Energy Service|Transportation|Passenger|Road|LDV
 - Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle|{Drive Type}:
     description: Energy service demand for passenger transport on roads in light duty vehicles
       with {Drive Type}
     unit: billion pkm/yr
     tier: 2
     navigate: Energy Service|Transportation|Road|LDV|{Drive Type}
+- Energy Service|Transportation|Passenger|Aviation:
+    description: Energy service demand for passenger transport on through aviation
+    unit: billion pkm/yr
+    tier: 2
+    navigate: Energy Service|Bunkers|Passenger|International Aviation
+    ngfs5: Energy Service|Transportation|Passenger|Aviation
 - Energy Service|Transportation|Freight|Truck:
     description: Energy service demand for freight transport on roads in trucks
     unit: billion tkm/yr
@@ -19,3 +27,14 @@
     unit: billion tkm/yr
     tier: 2
     navigate: Energy Service|Transportation|Freight|Truck|{Drive Type}
+- Energy Service|Transportation|Freight|International Aviation:
+    description: Energy service demand for freight transport through international aviation
+    unit: billion tkm/yr
+    tier: 2
+    navigate: Energy Service|Bunkers|Freight|International Aviation
+- Energy Service|Transportation|Freight|International Shipping:
+    description: Energy service demand for freight transport through international shipping
+    unit: billion tkm/yr
+    tier: 2
+    navigate: Energy Service|Bunkers|Freight|International Shipping
+    ngfs5: Energy Service|Transportation|Freight|International Shipping

--- a/definitions/variable/transport/stocks-sales.yaml
+++ b/definitions/variable/transport/stocks-sales.yaml
@@ -2,6 +2,8 @@
     description: Number of sold {Vehicle Type}
     unit: million
     tier: 2
+    # Only if `Vehicle Type` == Light-Duty Vehicle
+    ngfs5: Transport|Stock|Road|Passenger|LDV
 - Sales|Transportation|{Vehicle Type}|{Drive Type}:
     description: Number of sold {Vehicle Type} with {Drive Type}
     unit: million


### PR DESCRIPTION
Some variables from old projects (NAVIGATE, SHAPE, NGFS Phase 5) are currently not mapped correctly onto the common-definitions variables.

This affects variables in the industry and transport sectors for emissions, final energy, energy service, and production.

For some variables, the current notation does not work, because the tag is different between source and the target (e.g. `Iron and Steel` in common-definitions and `Steel` in another project).

Here is a list of points to consider:

1. `Production|Steel` from SHAPE is not mapped to `Production|Iron and Steel|Steel`. This should now be fixed by:
```diff
    - Production|Iron and Steel|{Iron Commodity}:
        description: Production of {Iron Commodity}
        unit: Mt/yr
        tier: 2
        navigate: Production|Iron and Steel|{Iron Commodity}|Volume
        engage: Production|Iron and Steel|{Iron Commodity}|Volume
        ngfs5: Production|{Iron Commodity}
+       shape: Production|{Iron Commodity}
```

2. `Production|Non-Metallic Minerals|Cement|Volume` from SHAPE __is__ in fact mapped to `Production|Non-Metallic Minerals|Cement`, even though it is not defined. Is this addition necessary?
```diff
    - Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}:
        description: Production of {Non-Metallic Minerals Commodity}
        unit: Mt/yr
        tier: 2
        navigate: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
        engage: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
        ngfs5: Production|{Non-Metallic Minerals Commodity}
+       # Is this needed? The variable seems to be already imported successfully.
+       shape: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}|Volume
```

3. `Emissions|CO2|Energy|Demand|Industry|Steel` from NAVIGATE, SHAPE, and NGFS Phase 5 seems to not be mapped to `Emissions|CO2|Energy|Demand|Industry|Iron and Steel` or anything else. This should now be fixed by:
```diff
    - Emissions|CO2|Energy|Demand|Industry|{Non-Energy Sector}:
        description: Emissions of carbon dioxide (CO2) from energy demand in the {Non-Energy Sector}
        unit: Mt CO2/yr
        tier: 2
        # Only if `Non-Energy Sector` == "Iron and Steel"
+       navigate: Emissions|CO2|Energy|Demand|Industry|Steel
+       ngfs5: Emissions|CO2|Energy|Demand|Industry|Steel
+       shape: Emissions|CO2|Energy|Demand|Industry|Steel
```
Note that:
* The issue with the tag mismatch needs to be resolved.
* There might be a small mismatch between the sector definitions of the projects (the Steel sector is part of but not equal to the Iron and Steel sector).

4. `Emissions|CO2|Industrial Processes|Iron and Steel` does not seem to be copied over from NAVIGATE. It does for SHAPE, even though this is not defined. Moreover `Emissions|Kyoto Gases|Steel` from NGFS Phase 5 does not seem to be mapped to anything. Possible way to deal with this:
```diff
    - Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}:
        description: Emissions of {Level-3 Species} from industrial processes
        (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Non-Energy Sector}
        unit: "{Level-3 Species}"
        tier: 2
+       navigate: Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}
+       # Only if `Non-Energy Sector` == "Iron and Steel"
+       ngfs5: Emissions|{Level-3 Species}|Steel
+       shape: Emissions|{Level-3 Species}|Industrial Processes|{Non-Energy Sector}
```
Note that:
* The issue with the tag mismatch needs to be resolved for NGFS Phase 5.
* It isn't entirely clear what emissions `Emissions|Kyoto Gases|Steel` are referring to. Is this `Emissions|Kyoto Gases|Energy|Demand|Industry|Iron and Steel` or `Emissions|Kyoto Gases|Industrial Processes|Iron and Steel`?
* It's not clear if the additions for NAVIGATE and SHAPE are needed, given that the copying seems to work for SHAPE.

5. `Emissions|CO2|Industrial Processes|Non-Metallic Minerals|Cement` from NAVIGATE does not seem to be mapped onto `Emissions|CO2|Industrial Processes|Cement`. This should now be fixed by:
```diff
    - Emissions|{Level-3 Species}|Industrial Processes|{Industrial-Process Sector}:
        description: Emissions of {Level-3 Species} from industrial processes
        (IPCC categories 1A2, 1A5, 2A, 2B, 2C, 2E) in the {Industrial-Process Sector}
        unit: "{Level-3 Species}"
        tier: 2
+       # Only when `Industrial-Process Sector` == "Cement"
+       navigate: Emissions|{Level-3 Species}|Industrial Processes|Non-Metallic Minerals|Cement
```

6. `Final Energy|Industry|Steel` from NGFS Phase 5 does not get mapped onto `Final Energy|Industry|Iron and Steel`.  This should now be fixed by:
```diff
    - Final Energy|{Sector}:
        description: Final energy consumption by the {Sector}
        unit: EJ/yr
        tier: 1
+       # Only when `Sector` == "Industry|Iron and Steel"
+       ngfs_phase_5: Final Energy|Industry|Steel
```
Note that:
* The issue with the tag mismatch needs to be resolved.

7. `Final Energy|Industry|Steel|Solids|Fossil` from NGFS Phase 5 does not get mapped onto `Final Energy|Industry|Iron and Steel|Solids|Coal`.  This should now be fixed by:
```diff
    - Final Energy|{Sector}:
        description: Final energy consumption by the {Sector}
        unit: EJ/yr
        tier: 1
+       # Only when `Sector` == "Industry|Iron and Steel" and `Secondary Fuel Level 2` == "Solids|Coal"
+       ngfs_phase_5: Final Energy|Industry|Steel|Solids|Fossil
```
Note that:
* The issue with the tag mismatch needs to be resolved.

8. `Energy Service|Transportation|Passenger|Road|LDV` from NAVIGATE, SHAPE, and NGFS Phase 5 does not get mapped onto `Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle`. This should now be fixed by:
```diff
    - Energy Service|Transportation|Passenger|Road|Light-Duty Vehicle:
        description: Energy service demand for passenger transport on roads in light duty vehicles
        unit: billion pkm/yr
        tier: 2
-       navigate: Energy Service|Transportation|Road|LDV
+       navigate: Energy Service|Transportation|Passenger|Road|LDV
+       ngfs5: Energy Service|Transportation|Passenger|Road|LDV
+       shape: Energy Service|Transportation|Passenger|Road|LDV
```

9. `Energy Service|Transportation|Passenger|Aviation` or similar does not seem to exist at all in common definitions. To map this variable from NGFS Phase 5 and also `Energy Service|Bunkers|Passenger|International Aviation` from NAVIGATE, I have added this:
```diff
+ - Energy Service|Transportation|Passenger|Aviation:
+     description: Energy service demand for passenger transport on through aviation
+     unit: billion pkm/yr
+     tier: 2
+     navigate: Energy Service|Bunkers|Passenger|International Aviation
+     ngfs5: Energy Service|Transportation|Passenger|Aviation
```
Note that:
* It is unclear if the convention should be `Energy Service|Transportation|...` or `Energy Service|Bunkers|...`.
* It is unclear if/how the split between domestic and international aviation should be carried through.

10. Same as 9. from above but for freight:
```diff
+ - Energy Service|Transportation|Freight|International Aviation:
+     description: Energy service demand for freight transport through international aviation
+     unit: billion tkm/yr
+     tier: 2
+     navigate: Energy Service|Bunkers|Freight|International Aviation
+ - Energy Service|Transportation|Freight|International Shipping:
+     description: Energy service demand for freight transport through international shipping
+     unit: billion tkm/yr
+     tier: 2
+     navigate: Energy Service|Bunkers|Freight|International Shipping
+     ngfs5: Energy Service|Transportation|Freight|International Shipping
```