### PR TITLE
Renaming `Production|Steel` in legacy project(s) to `Production|Iron and Steel|Steel`

### DIFF
--- a/legacy/variable-cleanup.yaml
+++ b/legacy/variable-cleanup.yaml
@@ -1,0 +1,4 @@
+dimension: variable
+rename:
+    # Variable `Production|Steel` isn't correctly mapped to `Production|Iron and Steel|Steel` in SHAPE.
+  - "Production|Steel": "Production|Iron and Steel|Steel"


### PR DESCRIPTION
The variable `Production|Steel` from SHAPE is not mapped to `Production|Iron and Steel|Steel`. This is a problem in projects relying on common-definitions that try to import scenarios from legacy projects.

It should be possible to resolve this by adding a `variable-cleanup.yml` in the `legacy` subdirectory, as suggested by this PR.

This PR is based on discussions in #338.