### PR TITLE
Adding biomass subcategories for energy-related emissions

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -334,6 +334,11 @@
     description: Emissions of {Level-2 Species} from fuel combustion in industry (IPCC category 1A2)
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Industry|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of {Energy-Related Emissions By Fuel}
+      in industry (IPCC category 1A2)
+    unit: "{Level-2 Species}"
+    tier: 2
 - Gross Emissions|CO2|Energy|Demand|Industry:
     description: Gross emissions of carbon dioxide (CO2) from fuel combustion in industry (IPCC category 1A2),
       not accounting for removals from the atmosphere
@@ -349,9 +354,20 @@
       and agriculture, forestry and fishing (AFOFI) (IPCC category 1A4c)
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial and AFOFI|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of {Energy-Related Emissions By Fuel}
+      in residential, commercial and institutional sectors (IPCC category 1A4a and 1A4b)
+      and agriculture, forestry and fishing (AFOFI) (IPCC category 1A4c)
+    unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial:
     description: Emissions of {Level-2 Species} from fuel combustion in residential,
       commercial and institutional sectors (IPCC category 1A4a and 1A4b)
+    unit: "{Level-2 Species}"
+    tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Residential and Commercial|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of {Energy-Related Emissions By Fuel}
+      in residential, commercial and institutional sectors (IPCC category 1A4a and 1A4b)
     unit: "{Level-2 Species}"
     tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Residential:
@@ -359,9 +375,19 @@
       sector (IPCC category 1A4b)
     unit: "{Level-2 Species}"
     tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Residential|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of {Energy-Related Emissions By Fuel}
+      in the residential sector (IPCC category 1A4b)
+    unit: "{Level-2 Species}"
+    tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Commercial:
     description: Emissions of {Level-2 Species} from fuel combustion in the commercial
       and institutional sectors (IPCC category 1A4a)
+    unit: "{Level-2 Species}"
+    tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|Commercial|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of {Energy-Related Emissions By Fuel}
+      in the commercial and institutional sectors (IPCC category 1A4a)
     unit: "{Level-2 Species}"
     tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Transportation:
@@ -391,6 +417,12 @@
 - Emissions|{Level-2 Species}|Energy|Demand|AFOFI:
     description: Emissions of {Level-2 Species} from fuel combustion in agriculture,
       forestry, fishing (AFOFI) (IPCC category 1A4c)
+    unit: "{Level-2 Species}"
+    tier: 2
+- Emissions|{Level-2 Species}|Energy|Demand|AFOFI|{Energy-Related Emissions By Fuel}:
+    description: Emissions of {Level-2 Species} from combustion of
+      {Energy-Related Emissions By Fuel} in agriculture, forestry, fishing (AFOFI)
+      (IPCC category 1A4c)
     unit: "{Level-2 Species}"
     tier: 2
 - Emissions|{Level-2 Species}|Energy|Demand|Bunkers:

--- a/definitions/variable/emissions/tag_energy_emissions_by_fuel.yaml
+++ b/definitions/variable/emissions/tag_energy_emissions_by_fuel.yaml
@@ -1,0 +1,16 @@
+- Energy-Related Emissions By Fuel:
+    # This list has selected fuels and source for additional detail of emissions
+    # from energy use for comparison to reference data
+    # It follows the structure of `tag_secondary_energy_carriers_level-2.yaml`
+    # but without the top-level category (Solids, Liquids, Gases)
+    - Biomass:
+        description: solid biomass (e.g., commercial charcoal, wood chips, wood pellets),
+          not including traditional bioenergy
+        tier: ^1
+    - Biomass|Modern:
+        description: modern biomass including 2nd generation bioenergy crops, crop and
+          forestry residue and municipal solid waste bioenergy
+        tier: ^1
+    - Biomass|Traditional:
+        description: traditional biomass including fuelwood
+        tier: ^1


### PR DESCRIPTION
This PR adds biomass-specific subcategories for emissions from energy demand (use). It's similar to #347 but implements a tag-list to be extendable easily later on, per discussion with @volker-krey.

I assume that we are only interested in fuel-source-specific detail (biomass, later maybe biofuels) but not the type of fuel (solids, liquids, gases) so I have omitted this intermediate aggregation. Per the comment by @VassilisDaioglou at https://github.com/IAMconsortium/common-definitions/pull/347#issuecomment-3370597181, I have added modern vs. traditional biomass subcategories.

I also believe that this sub-division does not make sense for Industrial Process emissions, so I have omitted it.