### PR TITLE
adding gcam-ceew-cdr v6

### DIFF
--- a/mappings/GCAM/GCAM-CEEW-CDR_v6.yaml
+++ b/mappings/GCAM/GCAM-CEEW-CDR_v6.yaml
@@ -1,0 +1,215 @@
+model:
+  - GCAM CEEW CDR v6
+native_regions:
+  - Africa_Eastern: GCAM CEEW CDR v6|Africa_Eastern
+  - Africa_Northern: GCAM CEEW CDR v6|Africa_Northern
+  - Africa_Southern: GCAM CEEW CDR v6|Africa_Southern
+  - Africa_Western: GCAM CEEW CDR v6|Africa_Western
+  - Argentina: GCAM CEEW CDR v6|Argentina
+  - Australia_NZ: GCAM CEEW CDR v6|Australia and New Zealand
+  - Brazil: GCAM CEEW CDR v6|Brazil
+  - Canada: GCAM CEEW CDR v6|Canada
+  - Central America and Caribbean: GCAM CEEW CDR v6|Central America and Caribbean
+  - Central Asia: GCAM CEEW CDR v6|Central Asia
+  - China: GCAM CEEW CDR v6|China
+  - Colombia: GCAM CEEW CDR v6|Colombia
+  - EU-12: GCAM CEEW CDR v6|EU-12
+  - EU-15: GCAM CEEW CDR v6|EU-15
+  - Europe_Eastern: GCAM CEEW CDR v6|Europe_Eastern
+  - Europe_Non_EU: GCAM CEEW CDR v6|Europe_Non_EU
+  - European Free Trade Association: GCAM CEEW CDR v6|European Free Trade Association
+  - India: GCAM CEEW CDR v6|India
+  - Indonesia: GCAM CEEW CDR v6|Indonesia
+  - Japan: GCAM CEEW CDR v6|Japan
+  - Mexico: GCAM CEEW CDR v6|Mexico
+  - Middle East: GCAM CEEW CDR v6|Middle East
+  - Pakistan: GCAM CEEW CDR v6|Pakistan
+  - Russia: GCAM CEEW CDR v6|Russia
+  - South Africa: GCAM CEEW CDR v6|South Africa
+  - South America_Northern: GCAM CEEW CDR v6|South America_Northern
+  - South America_Southern: GCAM CEEW CDR v6|South America_Southern
+  - South Asia: GCAM CEEW CDR v6|South Asia
+  - South Korea: GCAM CEEW CDR v6|South Korea
+  - Southeast Asia: GCAM CEEW CDR v6|Southeast Asia
+  - Taiwan: GCAM CEEW CDR v6|Taiwan
+  - USA: GCAM CEEW CDR v6|USA
+  # G20 members (without renaming)
+  - Brazil
+  - Canada
+  - China
+  - India
+  - Japan
+  - South Korea
+
+common_regions:
+  - World:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Argentina
+      - Australia_NZ
+      - Brazil
+      - Canada
+      - Central America and Caribbean
+      - Central Asia
+      - China
+      - Colombia
+      - EU-12
+      - EU-15
+      - Europe_Eastern
+      - Europe_Non_EU
+      - European Free Trade Association
+      - India
+      - Indonesia
+      - Japan
+      - Mexico
+      - Middle East
+      - Pakistan
+      - Russia
+      - South Africa
+      - South America_Northern
+      - South America_Southern
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+      - USA
+
+  # R5 regions
+  - Asia (R5):
+      - China
+      - India
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Latin America (R5):
+      - Brazil
+      - Central America and Caribbean
+      - Mexico
+      - South America_Northern
+      - South America_Southern
+      - Argentina
+      - Colombia
+  - Middle East & Africa (R5):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Middle East
+      - South Africa
+  - OECD & EU (R5):
+      - USA
+      - Australia_NZ
+      - Canada
+      - EU-12
+      - EU-15
+      - Europe_Non_EU
+      - European Free Trade Association
+      - Japan
+  - Reforming Economies (R5):
+      - Central Asia
+      - Europe_Eastern
+      - Russia
+
+  # R9 regions
+  - European Union (R9):
+      - EU-12
+      - EU-15
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - Canada
+      - Japan
+      - Australia_NZ
+      - Europe_Non_EU
+      - European Free Trade Association
+  - China (R9):
+      - China
+  - India (R9):
+      - India
+  - Other Asia (R9):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Reforming Economies (R9):
+      - Russia
+      - Central Asia
+      - Europe_Eastern
+  - Latin America (R9):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East & Africa (R9):
+      - Middle East
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+
+  # R10 regions
+  - Africa (R10):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+  - China+ (R10):
+      - China
+      - South Korea
+  - Europe (R10):
+      - EU-12
+      - EU-15
+      - Europe_Eastern
+      - Europe_Non_EU
+      - European Free Trade Association
+  - India+ (R10):
+      - India
+  - Latin America (R10):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East (R10):
+      - Middle East
+  - North America (R10):
+      - Canada
+      - USA
+  - Pacific OECD (R10):
+      - Japan
+      - Australia_NZ
+  - Reforming Economies (R10):
+      - Russia
+      - Central Asia
+  - Rest of Asia (R10):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - Southeast Asia
+      - Taiwan
+
+  # G20 members (aggregation or renaming)
+  - United States:
+      - USA
+  - African Union:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+  - European Union and United Kingdom:
+      - EU-12
+      - EU-15


### PR DESCRIPTION
We're registering our gcam-ceew-cdr v6 model for the SoCDR study. 

We only model the India region specifically. 

But since gcam is a global model it does have all the other regions. 
Kindly let us know if the yaml file in our model is required to only have the India region.