### PR TITLE
add new transport subsectors to tag_all_sectors.yaml

### DIFF
--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -129,8 +129,17 @@
     - Transportation|Truck:
         description: trucking sector
         tier: ^1
+    - Transportation|Road:
+        description: road transportation sector - both passenger and freight
+        tier: ^1
     - Transportation|Rail:
         description: rail transportation sector
+        tier: ^1
+    - Transportation|Rail|Passenger:
+        description: passenger rail transportation sector
+        tier: ^1
+    - Transportation|Rail|Freight:
+        description: freight rail transportation sector
         tier: ^1
     - Transportation|Domestic Aviation:
         description: domestic aviation sector


### PR DESCRIPTION
- added Transportation|Road: To be able to compare with real-world sources (eg IEA), the total for road transport is needed. 
- added Transportation|Rail|Passenger / Transportation|Rail|Freight: Rail is the only transportation sector that provides both passenger and freight energy services and is in many models modeled separately - so it is important to have this differentiation also in the reporting.