### PR TITLE
Add GEM-E3 V2026 definitions and mappings

### DIFF
--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -1,5 +1,4 @@
 - GEM-E3 V2026:
-  - GEM-E3 V2026|World
   - GEM-E3 V2026|Austria:
       countries:
       - Austria

--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -1,0 +1,346 @@
+- GEM-E3 V2026:
+  - GEM-E3 V2026|World
+  - GEM-E3 V2026|Austria:
+      countries:
+      - Austria
+  - GEM-E3 V2026|Belgium:
+      countries:
+      - Belgium
+  - GEM-E3 V2026|Bulgaria:
+      countries:
+      - Bulgaria
+  - GEM-E3 V2026|Cyprus:
+      countries:
+      - Cyprus
+  - GEM-E3 V2026|Croatia:
+      countries:
+      - Croatia
+  - GEM-E3 V2026|Czech Republic:
+      countries:
+      - Czechia
+  - GEM-E3 V2026|Germany:
+      countries:
+      - Germany
+  - GEM-E3 V2026|Denmark:
+      countries:
+      - Denmark
+  - GEM-E3 V2026|Spain:
+      countries:
+      - Spain
+  - GEM-E3 V2026|Estonia:
+      countries:
+      - Estonia
+  - GEM-E3 V2026|Finland:
+      countries:
+      - Finland
+  - GEM-E3 V2026|France:
+      countries:
+      - France
+  - GEM-E3 V2026|United Kingdom:
+      countries:
+      - United Kingdom
+  - GEM-E3 V2026|Greece:
+      countries:
+      - Greece
+  - GEM-E3 V2026|Hungary:
+      countries:
+      - Hungary
+  - GEM-E3 V2026|Ireland:
+      countries:
+      - Ireland
+  - GEM-E3 V2026|Italy:
+      countries:
+      - Italy
+  - GEM-E3 V2026|Lithuania:
+      countries:
+      - Lithuania
+  - GEM-E3 V2026|Luxembourg:
+      countries:
+      - Luxembourg
+  - GEM-E3 V2026|Latvia:
+      countries:
+      - Latvia
+  - GEM-E3 V2026|Malta:
+      countries:
+      - Malta
+  - GEM-E3 V2026|Netherlands:
+      countries:
+      - Netherlands
+  - GEM-E3 V2026|Poland:
+      countries:
+      - Poland
+  - GEM-E3 V2026|Portugal:
+      countries:
+      - Portugal
+  - GEM-E3 V2026|Slovakia:
+      countries:
+      - Slovakia
+  - GEM-E3 V2026|Slovenia:
+      countries:
+      - Slovenia
+  - GEM-E3 V2026|Sweden:
+      countries:
+      - Sweden
+  - GEM-E3 V2026|Romania:
+      countries:
+      - Romania
+  - GEM-E3 V2026|USA:
+      countries:
+      - United States
+  - GEM-E3 V2026|Japan:
+      countries:
+      - Japan
+  - GEM-E3 V2026|Canada:
+      countries:
+      - Canada
+  - GEM-E3 V2026|Brazil:
+      countries:
+      - Brazil
+  - GEM-E3 V2026|China:
+      countries:
+      - China
+  - GEM-E3 V2026|India:
+      countries:
+      - India
+  - GEM-E3 V2026|South Korea
+  - GEM-E3 V2026|Indonesia:
+      countries:
+      - Indonesia
+  - GEM-E3 V2026|Mexico:
+      countries:
+      - Mexico
+  - GEM-E3 V2026|Argentina:
+      countries:
+      - Argentina
+  - GEM-E3 V2026|Turkey:
+      countries:
+      - Turkey
+  - GEM-E3 V2026|Saudi Arabia:
+      countries:
+      - Saudi Arabia
+  - GEM-E3 V2026|Oceania:
+      countries:
+      - Australia
+      - New Zealand
+  - GEM-E3 V2026|Russian federation:
+      countries:
+      - Russian Federation
+  - GEM-E3 V2026|United Arab Emirates:
+      countries:
+      - United Arab Emirates
+  - GEM-E3 V2026|Rest of energy producing countries:
+      countries:
+      - Algeria
+      - Azerbaijan
+      - Iran
+      - Iraq
+      - Jordan
+      - Kuwait
+      - Lebanon
+      - Libya
+      - Nigeria
+      - Qatar
+      - Syria
+      - Venezuela
+      - Western Sahara
+      - Yemen
+  - GEM-E3 V2026|South Africa:
+      countries:
+      - South Africa
+  - GEM-E3 V2026|Rest of Europe:
+      countries:
+      - Belarus
+      - Bosnia and Herzegovina
+      - Iceland
+      - Kosovo
+      - Liechtenstein
+      - Moldova
+      - Monaco
+      - Montenegro
+      - North Macedonia
+      - Norway
+      - Serbia
+      - Switzerland
+      - Ukraine
+      - Vatican
+  - GEM-E3 V2026|Rest of the World:
+      countries:
+      - Afghanistan
+      - Åland Islands
+      - Albania
+      - American Samoa
+      - Andorra
+      - Angola
+      - Anguilla
+      - Antarctica
+      - Antigua and Barbuda
+      - Armenia
+      - Aruba
+      - Bahamas
+      - Bahrain
+      - Bangladesh
+      - Barbados
+      - Belize
+      - Benin
+      - Bermuda
+      - Bhutan
+      - Bolivia
+      - Bonaire, Sint Eustatius and Saba
+      - Botswana
+      - Bouvet Island
+      - British Indian Ocean Territory
+      - British Virgin Islands
+      - Brunei Darussalam
+      - Burkina Faso
+      - Burundi
+      - Cabo Verde
+      - Cambodia
+      - Cameroon
+      - Cayman Islands
+      - Central African Republic
+      - Chad
+      - Chile
+      - Christmas Island
+      - Cocos (Keeling) Islands
+      - Colombia
+      - Comoros
+      - Congo
+      - Cook Islands
+      - Costa Rica
+      - Côte d'Ivoire
+      - Cuba
+      - Curaçao
+      - Democratic Republic of the Congo
+      - Djibouti
+      - Dominica
+      - Dominican Republic
+      - Ecuador
+      - Egypt
+      - El Salvador
+      - Equatorial Guinea
+      - Eritrea
+      - Eswatini
+      - Ethiopia
+      - Falkland Islands (Malvinas)
+      - Faroe Islands
+      - Fiji
+      - French Guiana
+      - French Polynesia
+      - French Southern Territories
+      - Gabon
+      - Gambia
+      - Georgia
+      - Ghana
+      - Gibraltar
+      - Greenland
+      - Grenada
+      - Guadeloupe
+      - Guam
+      - Guatemala
+      - Guernsey
+      - Guinea
+      - Guinea-Bissau
+      - Guyana
+      - Haiti
+      - Heard Island and McDonald Islands
+      - Honduras
+      - Hong Kong
+      - Isle of Man
+      - Israel
+      - Jamaica
+      - Jersey
+      - Kazakhstan
+      - Kenya
+      - Kiribati
+      - Kyrgyzstan
+      - Laos
+      - Lesotho
+      - Liberia
+      - Macao
+      - Madagascar
+      - Malawi
+      - Malaysia
+      - Maldives
+      - Mali
+      - Marshall Islands
+      - Martinique
+      - Mauritania
+      - Mauritius
+      - Mayotte
+      - Micronesia
+      - Mongolia
+      - Montserrat
+      - Morocco
+      - Mozambique
+      - Myanmar
+      - Namibia
+      - Nauru
+      - Nepal
+      - New Caledonia
+      - Nicaragua
+      - Niger
+      - Niue
+      - Norfolk Island
+      - North Korea
+      - Northern Mariana Islands
+      - Oman
+      - Pakistan
+      - Palau
+      - Palestine
+      - Panama
+      - Papua New Guinea
+      - Paraguay
+      - Peru
+      - Philippines
+      - Pitcairn
+      - Puerto Rico
+      - Réunion
+      - Rwanda
+      - Saint Barthélemy
+      - Saint Helena, Ascension and Tristan da Cunha
+      - Saint Kitts and Nevis
+      - Saint Lucia
+      - Saint Martin (French part)
+      - Saint Pierre and Miquelon
+      - Saint Vincent and the Grenadines
+      - Samoa
+      - San Marino
+      - Sao Tome and Principe
+      - Senegal
+      - Seychelles
+      - Sierra Leone
+      - Singapore
+      - Sint Maarten (Dutch part)
+      - Solomon Islands
+      - Somalia
+      - South Georgia and the South Sandwich Islands
+      - South Korea
+      - South Sudan
+      - Sri Lanka
+      - Sudan
+      - Suriname
+      - Svalbard and Jan Mayen
+      - Taiwan
+      - Tajikistan
+      - Tanzania
+      - Thailand
+      - Timor-Leste
+      - Togo
+      - Tokelau
+      - Tonga
+      - Trinidad and Tobago
+      - Tunisia
+      - Turkmenistan
+      - Turks and Caicos Islands
+      - Tuvalu
+      - Uganda
+      - United States Minor Outlying Islands
+      - United States Virgin Islands
+      - Uruguay
+      - Uzbekistan
+      - Vanuatu
+      - Viet Nam
+      - Wallis and Futuna
+      - Zambia
+      - Zimbabwe
+  - GEM-E3 V2026|EU27

--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -128,7 +128,7 @@
   - GEM-E3 V2026|United Arab Emirates:
       countries:
       - United Arab Emirates
-  - GEM-E3 V2026|Rest of energy producing countries:
+  - GEM-E3 V2026|Other Major Fossil-Exporting Countries
       countries:
       - Algeria
       - Azerbaijan

--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -343,4 +343,3 @@
       - Wallis and Futuna
       - Zambia
       - Zimbabwe
-  - GEM-E3 V2026|EU27

--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -128,7 +128,7 @@
   - GEM-E3 V2026|United Arab Emirates:
       countries:
       - United Arab Emirates
-  - GEM-E3 V2026|Other Major Fossil-Exporting Countries
+  - GEM-E3 V2026|Other Major Fossil-Exporting Countries:
       countries:
       - Algeria
       - Azerbaijan

--- a/definitions/region/native_regions/GEM-E3_V2026.yaml
+++ b/definitions/region/native_regions/GEM-E3_V2026.yaml
@@ -122,7 +122,7 @@
       countries:
       - Australia
       - New Zealand
-  - GEM-E3 V2026|Russian federation:
+  - GEM-E3 V2026|Russian Federation:
       countries:
       - Russian Federation
   - GEM-E3 V2026|United Arab Emirates:

--- a/mappings/GEM-E3_V2026.yaml
+++ b/mappings/GEM-E3_V2026.yaml
@@ -1,6 +1,5 @@
 model: GEM-E3 V2026
 native_regions:
-- WORLD: World
 - AUT: GEM-E3 V2026|Austria
 - BEL: GEM-E3 V2026|Belgium
 - BGR: GEM-E3 V2026|Bulgaria

--- a/mappings/GEM-E3_V2026.yaml
+++ b/mappings/GEM-E3_V2026.yaml
@@ -42,13 +42,13 @@ native_regions:
 - TUR: GEM-E3 V2026|Turkey
 - SAR: GEM-E3 V2026|Saudi Arabia
 - OCE: GEM-E3 V2026|Oceania
-- RUS: GEM-E3 V2026|Russian federation
+- RUS: GEM-E3 V2026|Russian Federation
 - ARE: GEM-E3 V2026|United Arab Emirates
-- REP: GEM-E3 V2026|Rest of energy producing countries
+- REP: GEM-E3 V2026|Other Major Fossil-Exporting Countries
 - SAF: GEM-E3 V2026|South Africa
 - REU: GEM-E3 V2026|Rest of Europe
 - ROW: GEM-E3 V2026|Rest of the World
-- EU27: GEM-E3 V2026|EU27
+- EU27: European Union
 common_regions:
 - World:
   - ARE

--- a/mappings/GEM-E3_V2026.yaml
+++ b/mappings/GEM-E3_V2026.yaml
@@ -66,7 +66,6 @@ common_regions:
   - DNK
   - ESP
   - EST
-  - EU27
   - FIN
   - FRA
   - GBR
@@ -148,7 +147,6 @@ common_regions:
   - TUR
   - OCE
   - REU
-  - EU27
 - Other (R5):
   - ROW
 - Reforming Economies (R5):
@@ -189,7 +187,6 @@ common_regions:
   - ROU
   - TUR
   - REU
-  - EU27
 - India+ (R10):
   - IND
 - Latin America (R10):
@@ -242,7 +239,6 @@ common_regions:
   - SVN
   - SWE
   - ROU
-  - EU27
 - India (R9):
   - IND
 - Latin America (R9):

--- a/mappings/GEM-E3_V2026.yaml
+++ b/mappings/GEM-E3_V2026.yaml
@@ -1,0 +1,272 @@
+model: GEM-E3 V2026
+native_regions:
+- WORLD: GEM-E3 V2026|World
+- AUT: GEM-E3 V2026|Austria
+- BEL: GEM-E3 V2026|Belgium
+- BGR: GEM-E3 V2026|Bulgaria
+- CYP: GEM-E3 V2026|Cyprus
+- CRO: GEM-E3 V2026|Croatia
+- CZE: GEM-E3 V2026|Czech Republic
+- DEU: GEM-E3 V2026|Germany
+- DNK: GEM-E3 V2026|Denmark
+- ESP: GEM-E3 V2026|Spain
+- EST: GEM-E3 V2026|Estonia
+- FIN: GEM-E3 V2026|Finland
+- FRA: GEM-E3 V2026|France
+- GBR: GEM-E3 V2026|United Kingdom
+- GRC: GEM-E3 V2026|Greece
+- HUN: GEM-E3 V2026|Hungary
+- IRL: GEM-E3 V2026|Ireland
+- ITA: GEM-E3 V2026|Italy
+- LTU: GEM-E3 V2026|Lithuania
+- LUX: GEM-E3 V2026|Luxembourg
+- LVA: GEM-E3 V2026|Latvia
+- MLT: GEM-E3 V2026|Malta
+- NLD: GEM-E3 V2026|Netherlands
+- POL: GEM-E3 V2026|Poland
+- PRT: GEM-E3 V2026|Portugal
+- SVK: GEM-E3 V2026|Slovakia
+- SVN: GEM-E3 V2026|Slovenia
+- SWE: GEM-E3 V2026|Sweden
+- ROU: GEM-E3 V2026|Romania
+- USA: GEM-E3 V2026|USA
+- JPN: GEM-E3 V2026|Japan
+- CAN: GEM-E3 V2026|Canada
+- BRA: GEM-E3 V2026|Brazil
+- CHN: GEM-E3 V2026|China
+- IND: GEM-E3 V2026|India
+- KOR: GEM-E3 V2026|South Korea
+- IDN: GEM-E3 V2026|Indonesia
+- MEX: GEM-E3 V2026|Mexico
+- ARG: GEM-E3 V2026|Argentina
+- TUR: GEM-E3 V2026|Turkey
+- SAR: GEM-E3 V2026|Saudi Arabia
+- OCE: GEM-E3 V2026|Oceania
+- RUS: GEM-E3 V2026|Russian federation
+- ARE: GEM-E3 V2026|United Arab Emirates
+- REP: GEM-E3 V2026|Rest of energy producing countries
+- SAF: GEM-E3 V2026|South Africa
+- REU: GEM-E3 V2026|Rest of Europe
+- ROW: GEM-E3 V2026|Rest of the World
+- EU27: GEM-E3 V2026|EU27
+common_regions:
+- World:
+  - ARE
+  - ARG
+  - AUT
+  - BEL
+  - BGR
+  - BRA
+  - CAN
+  - CHN
+  - CRO
+  - CYP
+  - CZE
+  - DEU
+  - DNK
+  - ESP
+  - EST
+  - EU27
+  - FIN
+  - FRA
+  - GBR
+  - GRC
+  - HUN
+  - IDN
+  - IND
+  - IRL
+  - ITA
+  - JPN
+  - KOR
+  - LTU
+  - LUX
+  - LVA
+  - MEX
+  - MLT
+  - NLD
+  - OCE
+  - POL
+  - PRT
+  - REP
+  - REU
+  - ROU
+  - ROW
+  - RUS
+  - SAF
+  - SAR
+  - SVK
+  - SVN
+  - SWE
+  - TUR
+  - USA
+- Asia (R5):
+  - CHN
+  - IND
+  - KOR
+  - IDN
+- Latin America (R5):
+  - BRA
+  - MEX
+  - ARG
+- Middle East & Africa (R5):
+  - SAR
+  - ARE
+  - REP
+  - SAF
+- OECD & EU (R5):
+  - AUT
+  - BEL
+  - BGR
+  - CYP
+  - CRO
+  - CZE
+  - DEU
+  - DNK
+  - ESP
+  - EST
+  - FIN
+  - FRA
+  - GBR
+  - GRC
+  - HUN
+  - IRL
+  - ITA
+  - LTU
+  - LUX
+  - LVA
+  - MLT
+  - NLD
+  - POL
+  - PRT
+  - SVK
+  - SVN
+  - SWE
+  - ROU
+  - USA
+  - JPN
+  - CAN
+  - TUR
+  - OCE
+  - REU
+  - EU27
+- Other (R5):
+  - ROW
+- Reforming Economies (R5):
+  - RUS
+- Africa (R10):
+  - SAF
+- China+ (R10):
+  - CHN
+  - KOR
+- Europe (R10):
+  - AUT
+  - BEL
+  - BGR
+  - CYP
+  - CRO
+  - CZE
+  - DEU
+  - DNK
+  - ESP
+  - EST
+  - FIN
+  - FRA
+  - GBR
+  - GRC
+  - HUN
+  - IRL
+  - ITA
+  - LTU
+  - LUX
+  - LVA
+  - MLT
+  - NLD
+  - POL
+  - PRT
+  - SVK
+  - SVN
+  - SWE
+  - ROU
+  - TUR
+  - REU
+  - EU27
+- India+ (R10):
+  - IND
+- Latin America (R10):
+  - BRA
+  - MEX
+  - ARG
+- Middle East (R10):
+  - SAR
+  - ARE
+  - REP
+- North America (R10):
+  - USA
+  - CAN
+- Other (R10):
+  - ROW
+- Pacific OECD (R10):
+  - JPN
+  - OCE
+- Reforming Economies (R10):
+  - RUS
+- Rest of Asia (R10):
+  - IDN
+- China (R9):
+  - CHN
+- European Union (R9):
+  - AUT
+  - BEL
+  - BGR
+  - CYP
+  - CRO
+  - CZE
+  - DEU
+  - DNK
+  - ESP
+  - EST
+  - FIN
+  - FRA
+  - GRC
+  - HUN
+  - IRL
+  - ITA
+  - LTU
+  - LUX
+  - LVA
+  - MLT
+  - NLD
+  - POL
+  - PRT
+  - SVK
+  - SVN
+  - SWE
+  - ROU
+  - EU27
+- India (R9):
+  - IND
+- Latin America (R9):
+  - BRA
+  - MEX
+  - ARG
+- Middle East & Africa (R9):
+  - SAR
+  - ARE
+  - REP
+  - SAF
+- Other (R9):
+  - ROW
+- Other Asia (R9):
+  - KOR
+  - IDN
+- Other OECD (R9):
+  - GBR
+  - JPN
+  - CAN
+  - TUR
+  - OCE
+  - REU
+- Reforming Economies (R9):
+  - RUS
+- USA (R9):
+  - USA

--- a/mappings/GEM-E3_V2026.yaml
+++ b/mappings/GEM-E3_V2026.yaml
@@ -1,6 +1,6 @@
 model: GEM-E3 V2026
 native_regions:
-- WORLD: GEM-E3 V2026|World
+- WORLD: World
 - AUT: GEM-E3 V2026|Austria
 - BEL: GEM-E3 V2026|Belgium
 - BGR: GEM-E3 V2026|Bulgaria


### PR DESCRIPTION
Adds model region definitions and mappings for GEM-E3 V2026.

One detail to confirm: the `GEM-E3 V2026|EU27` region does not have its `countries` defined in the registration file, should these be added?