### PR TITLE
Add `GCAM 6.0` to model mapping

### DIFF
--- a/mappings/GCAM/GCAM_6.0.yaml
+++ b/mappings/GCAM/GCAM_6.0.yaml
@@ -1,4 +1,5 @@
 model:
+  - GCAM 6.0
   - GCAM 6.0 NGFS
 native_regions:
   - Africa_Eastern: GCAM 6.0|Africa_Eastern


### PR DESCRIPTION
This PR adds the model `GCAM 6.0` to the mappings for the hierarchy `GCAM 6.0`

FYI @jayfuhrman @d3y419 