### PR TITLE
Adding MESSAGEix-GLOBIOM-GAINS 2.1-BMT-R12 model

### DIFF
--- a/mappings/MESSAGEix-GLOBIOM/MESSAGEix-GLOBIOM-GAINS_2.1-BMT-R12.yaml
+++ b/mappings/MESSAGEix-GLOBIOM/MESSAGEix-GLOBIOM-GAINS_2.1-BMT-R12.yaml
@@ -1,0 +1,89 @@
+model:
+  - MESSAGEix-GLOBIOM-GAINS 2.1-BMT-R12
+
+native_regions:
+  - R12_AFR: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Sub-Saharan Africa
+  - R12_RCPA: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Rest of Centrally Planned Asia
+  - R12_CHN: MESSAGEix-GLOBIOM-GAINS 2.1-R12|China
+  - R12_EEU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Eastern Europe
+  - R12_FSU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Former Soviet Union
+  - R12_LAM: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Latin America and the Caribbean
+  - R12_MEA: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Middle East and North Africa
+  - R12_NAM: MESSAGEix-GLOBIOM-GAINS 2.1-R12|North America
+  - R12_PAO: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Pacific OECD
+  - R12_PAS: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Other Pacific Asia
+  - R12_SAS: MESSAGEix-GLOBIOM-GAINS 2.1-R12|South Asia
+  - R12_WEU: MESSAGEix-GLOBIOM-GAINS 2.1-R12|Western Europe
+
+common_regions:
+  - World:
+      - R12_AFR
+      - R12_RCPA
+      - R12_CHN
+      - R12_EEU
+      - R12_FSU
+      - R12_LAM
+      - R12_MEA
+      - R12_NAM
+      - R12_PAO
+      - R12_PAS
+      - R12_SAS
+      - R12_WEU
+
+  # R5 regions
+  - Asia (R5):
+      - R12_SAS
+      - R12_PAS
+      - R12_RCPA
+      - R12_CHN
+  - Latin America (R5):
+      - R12_LAM
+  - Middle East & Africa (R5):
+      - R12_MEA
+      - R12_AFR
+  - OECD & EU (R5):
+      - R12_WEU
+      - R12_PAO
+      - R12_NAM
+      - R12_EEU
+  - Reforming Economies (R5):
+      - R12_FSU
+
+  # R10 regions
+  - Africa (R10):
+      - R12_AFR
+  - China+ (R10):
+      - R12_CHN
+      - R12_RCPA
+  - Europe (R10):
+      - R12_EEU
+      - R12_WEU
+  - India+ (R10):
+      - R12_SAS
+  - Latin America (R10):
+      - R12_LAM
+  - Middle East (R10):
+      - R12_MEA
+  - North America (R10):
+      - R12_NAM
+  - Pacific OECD (R10):
+      - R12_PAO
+  - Reforming Economies (R10):
+      - R12_FSU
+  - Rest of Asia (R10):
+      - R12_PAS
+
+  - China:
+      - R12_CHN
+  - European Union and United Kingdom:
+      - R12_EEU
+      - R12_WEU
+  - India:
+      - R12_SAS
+  - Japan:
+      - R12_PAO
+  - Russian Federation:
+      - R12_FSU
+  - United States:
+      - R12_NAM
+


### PR DESCRIPTION
Note that native region names use 'MESSAGEix-GLOBIOM-GAINS 2.1-R12' as a prefix similar to the 'MESSAGEix-GLOBIOM-GAINS 2.1-M-R12' model. So, both don't include the '-M' and '-BMT' insert in the region name and therefore share the same native region names which is a benefit when comparing scenarios across the two model variants.
