### PR TITLE
Register GCAM 8.4 & GCAM 9.1

### DIFF
--- a/definitions/region/native_regions/GCAM/GCAM_8.4.yaml
+++ b/definitions/region/native_regions/GCAM/GCAM_8.4.yaml
@@ -1,0 +1,113 @@
+- GCAM 8.4:
+    - GCAM 8.4|Africa_Eastern:
+        countries: [
+          Burundi, Comoros, Djibouti, Eritrea, Ethiopia, Kenya, Madagascar, Mauritius,
+          Réunion, Rwanda, Somalia, Sudan, South Sudan, Uganda
+        ]
+    - GCAM 8.4|Africa_Northern:
+        countries: [
+          Algeria, Egypt, Libya, Morocco, Tunisia, Western Sahara
+        ]
+    - GCAM 8.4|Africa_Southern:
+        countries: [
+          Angola, Mozambique, Malawi, Lesotho, Botswana, Tanzania, Namibia, Eswatini,
+          Zambia, Zimbabwe
+        ]
+    - GCAM 8.4|Africa_Western:
+        countries: [
+          Benin, Congo, Democratic Republic of the Congo, Cameroon, Chad,
+          Central African Republic, Cabo Verde, Equatorial Guinea, Gambia, Gabon, Ghana,
+          Guinea, Côte d'Ivoire, Liberia, Mali, Mauritania, Niger, Nigeria, Guinea-Bissau,
+          Senegal, Sierra Leone, Togo, Sao Tome and Principe, Burkina Faso,
+          "Saint Helena, Ascension and Tristan da Cunha"
+        ]
+    - GCAM 8.4|Argentina:
+        countries: Argentina
+    - GCAM 8.4|Australia and New Zealand:
+        countries: [ Australia, New Zealand ]
+    - GCAM 8.4|Brazil:
+        countries: Brazil
+    - GCAM 8.4|Canada:
+        countries: Canada
+    - GCAM 8.4|Central America and Caribbean:
+        countries: [
+          Antigua and Barbuda, Barbados, Bermuda, Bahamas, Belize, Cayman Islands,
+          Costa Rica, Cuba, Dominica, Dominican Republic, El Salvador, Grenada, Guatemala,
+          Haiti, Honduras, Jamaica, Martinique, Montserrat, Aruba, Anguilla, Nicaragua,
+          Panama, Saint Kitts and Nevis, Saint Lucia, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Guadeloupe,
+          "Bonaire, Sint Eustatius and Saba", Curaçao, Saint Martin (French part),
+          Sint Maarten (Dutch part)
+        ]
+    - GCAM 8.4|Central Asia:
+        countries: [
+          Azerbaijan, Armenia, Georgia, Kyrgyzstan, Kazakhstan, Mongolia, Tajikistan,
+          Turkmenistan, Uzbekistan
+        ]
+    - GCAM 8.4|China:
+        countries: [ China, Hong Kong, Macao ]
+    - GCAM 8.4|Colombia:
+        countries: Colombia
+    - GCAM 8.4|EU-12:
+        countries: [
+          Bulgaria, Cyprus, Estonia, Czechia, Hungary, Latvia, Lithuania, Slovakia,
+          Malta, Poland, Romania, Slovenia
+        ]
+    - GCAM 8.4|EU-15:
+        countries: [
+          Denmark, Ireland, Austria, Finland, Falkland Islands (Malvinas), France,
+          Greenland, Germany, Greece, Italy, Belgium, Faroe Islands, Andorra, Gibraltar,
+          Isle of Man, Luxembourg, Monaco, Netherlands, Portugal, Spain, Sweden,
+          United Kingdom, British Virgin Islands, Saint Pierre and Miquelon, San Marino,
+          Turks and Caicos Islands, Guernsey, Jersey, Vatican
+        ]
+    - GCAM 8.4|Ukraine:
+        countries: [ Ukraine ]
+    - GCAM 8.4|Europe_Southeast:
+        countries: [
+          Albania, Bosnia and Herzegovina, Belarus, Croatia,  Moldova, Kosovo, North Macedonia, Montenegro,
+          Turkey, Serbia
+        ]
+    - GCAM 8.4|European Free Trade Association:
+        countries: [ Iceland, Liechtenstein, Norway, Switzerland, Svalbard and Jan Mayen ]
+    - GCAM 8.4|India:
+        countries: India
+    - GCAM 8.4|Indonesia:
+        countries: Indonesia
+    - GCAM 8.4|Japan:
+        countries: Japan
+    - GCAM 8.4|Mexico:
+        countries: Mexico
+    - GCAM 8.4|Middle East:
+        countries: [
+          Bahrain, Iran, Israel, Iraq, Jordan, Kuwait, Lebanon, Oman, Palestine, Qatar,
+          Saudi Arabia, Syria, Yemen, United Arab Emirates
+        ]
+    - GCAM 8.4|Pakistan:
+        countries: Pakistan
+    - GCAM 8.4|Russia:
+        countries: Russian Federation
+    - GCAM 8.4|South Africa:
+        countries: South Africa
+    - GCAM 8.4|South America_Northern:
+        countries: [ French Guiana, Guyana, Suriname, Venezuela ]
+    - GCAM 8.4|South America_Southern:
+        countries: [ Bolivia, Chile, Ecuador, Paraguay, Peru, Uruguay ]
+    - GCAM 8.4|South Asia:
+        countries: [ Bangladesh, Sri Lanka, Afghanistan, Bhutan, Maldives, Nepal ]
+    - GCAM 8.4|South Korea:
+        countries: South Korea
+    - GCAM 8.4|Southeast Asia:
+        countries: [
+          American Samoa, Myanmar, Solomon Islands, Brunei Darussalam, Cambodia,
+          Cook Islands, Fiji, Micronesia, French Polynesia, Guam, North Korea, Kiribati,
+          Laos, Malaysia, New Caledonia, Niue, Northern Mariana Islands, Mayotte,
+          Norfolk Island, Cocos (Keeling) Islands, Christmas Island, Vanuatu, Nauru,
+          Papua New Guinea, Philippines, Seychelles, Singapore, Thailand, Tokelau,
+          Tonga, Tuvalu, Viet Nam, Samoa, Timor-Leste, Palau, Marshall Islands,
+          Pitcairn, Wallis and Futuna
+        ]
+    - GCAM 8.4|Taiwan:
+        countries: Taiwan
+    - GCAM 8.4|USA:
+        countries: [ Puerto Rico, United States, United States Virgin Islands ]

--- a/definitions/region/native_regions/GCAM/GCAM_9.1.yaml
+++ b/definitions/region/native_regions/GCAM/GCAM_9.1.yaml
@@ -1,0 +1,113 @@
+- GCAM 9.1:
+    - GCAM 9.1|Africa_Eastern:
+        countries: [
+          Burundi, Comoros, Djibouti, Eritrea, Ethiopia, Kenya, Madagascar, Mauritius,
+          Réunion, Rwanda, Somalia, Sudan, South Sudan, Uganda
+        ]
+    - GCAM 9.1|Africa_Northern:
+        countries: [
+          Algeria, Egypt, Libya, Morocco, Tunisia, Western Sahara
+        ]
+    - GCAM 9.1|Africa_Southern:
+        countries: [
+          Angola, Mozambique, Malawi, Lesotho, Botswana, Tanzania, Namibia, Eswatini,
+          Zambia, Zimbabwe
+        ]
+    - GCAM 9.1|Africa_Western:
+        countries: [
+          Benin, Congo, Democratic Republic of the Congo, Cameroon, Chad,
+          Central African Republic, Cabo Verde, Equatorial Guinea, Gambia, Gabon, Ghana,
+          Guinea, Côte d'Ivoire, Liberia, Mali, Mauritania, Niger, Nigeria, Guinea-Bissau,
+          Senegal, Sierra Leone, Togo, Sao Tome and Principe, Burkina Faso,
+          "Saint Helena, Ascension and Tristan da Cunha"
+        ]
+    - GCAM 9.1|Argentina:
+        countries: Argentina
+    - GCAM 9.1|Australia and New Zealand:
+        countries: [ Australia, New Zealand ]
+    - GCAM 9.1|Brazil:
+        countries: Brazil
+    - GCAM 9.1|Canada:
+        countries: Canada
+    - GCAM 9.1|Central America and Caribbean:
+        countries: [
+          Antigua and Barbuda, Barbados, Bermuda, Bahamas, Belize, Cayman Islands,
+          Costa Rica, Cuba, Dominica, Dominican Republic, El Salvador, Grenada, Guatemala,
+          Haiti, Honduras, Jamaica, Martinique, Montserrat, Aruba, Anguilla, Nicaragua,
+          Panama, Saint Kitts and Nevis, Saint Lucia, Trinidad and Tobago,
+          Saint Vincent and the Grenadines, Guadeloupe,
+          "Bonaire, Sint Eustatius and Saba", Curaçao, Saint Martin (French part),
+          Sint Maarten (Dutch part)
+        ]
+    - GCAM 9.1|Central Asia:
+        countries: [
+          Azerbaijan, Armenia, Georgia, Kyrgyzstan, Kazakhstan, Mongolia, Tajikistan,
+          Turkmenistan, Uzbekistan
+        ]
+    - GCAM 9.1|China:
+        countries: [ China, Hong Kong, Macao ]
+    - GCAM 9.1|Colombia:
+        countries: Colombia
+    - GCAM 9.1|EU-12:
+        countries: [
+          Bulgaria, Cyprus, Estonia, Czechia, Hungary, Latvia, Lithuania, Slovakia,
+          Malta, Poland, Romania, Slovenia
+        ]
+    - GCAM 9.1|EU-15:
+        countries: [
+          Denmark, Ireland, Austria, Finland, Falkland Islands (Malvinas), France,
+          Greenland, Germany, Greece, Italy, Belgium, Faroe Islands, Andorra, Gibraltar,
+          Isle of Man, Luxembourg, Monaco, Netherlands, Portugal, Spain, Sweden,
+          United Kingdom, British Virgin Islands, Saint Pierre and Miquelon, San Marino,
+          Turks and Caicos Islands, Guernsey, Jersey, Vatican
+        ]
+    - GCAM 9.1|Ukraine:
+        countries: [ Ukraine ]
+    - GCAM 9.1|Europe_Southeast:
+        countries: [
+          Albania, Bosnia and Herzegovina, Belarus, Croatia,  Moldova, Kosovo, North Macedonia, Montenegro,
+          Turkey, Serbia
+        ]
+    - GCAM 9.1|European Free Trade Association:
+        countries: [ Iceland, Liechtenstein, Norway, Switzerland, Svalbard and Jan Mayen ]
+    - GCAM 9.1|India:
+        countries: India
+    - GCAM 9.1|Indonesia:
+        countries: Indonesia
+    - GCAM 9.1|Japan:
+        countries: Japan
+    - GCAM 9.1|Mexico:
+        countries: Mexico
+    - GCAM 9.1|Middle East:
+        countries: [
+          Bahrain, Iran, Israel, Iraq, Jordan, Kuwait, Lebanon, Oman, Palestine, Qatar,
+          Saudi Arabia, Syria, Yemen, United Arab Emirates
+        ]
+    - GCAM 9.1|Pakistan:
+        countries: Pakistan
+    - GCAM 9.1|Russia:
+        countries: Russian Federation
+    - GCAM 9.1|South Africa:
+        countries: South Africa
+    - GCAM 9.1|South America_Northern:
+        countries: [ French Guiana, Guyana, Suriname, Venezuela ]
+    - GCAM 9.1|South America_Southern:
+        countries: [ Bolivia, Chile, Ecuador, Paraguay, Peru, Uruguay ]
+    - GCAM 9.1|South Asia:
+        countries: [ Bangladesh, Sri Lanka, Afghanistan, Bhutan, Maldives, Nepal ]
+    - GCAM 9.1|South Korea:
+        countries: South Korea
+    - GCAM 9.1|Southeast Asia:
+        countries: [
+          American Samoa, Myanmar, Solomon Islands, Brunei Darussalam, Cambodia,
+          Cook Islands, Fiji, Micronesia, French Polynesia, Guam, North Korea, Kiribati,
+          Laos, Malaysia, New Caledonia, Niue, Northern Mariana Islands, Mayotte,
+          Norfolk Island, Cocos (Keeling) Islands, Christmas Island, Vanuatu, Nauru,
+          Papua New Guinea, Philippines, Seychelles, Singapore, Thailand, Tokelau,
+          Tonga, Tuvalu, Viet Nam, Samoa, Timor-Leste, Palau, Marshall Islands,
+          Pitcairn, Wallis and Futuna
+        ]
+    - GCAM 9.1|Taiwan:
+        countries: Taiwan
+    - GCAM 9.1|USA:
+        countries: [ Puerto Rico, United States, United States Virgin Islands ]

--- a/mappings/GCAM/GCAM_8.4.yaml
+++ b/mappings/GCAM/GCAM_8.4.yaml
@@ -1,0 +1,217 @@
+model:
+  - GCAM 8.4
+  - GCAM-CGS 8.4
+
+native_regions:
+  - Africa_Eastern: GCAM 8.4|Africa_Eastern
+  - Africa_Northern: GCAM 8.4|Africa_Northern
+  - Africa_Southern: GCAM 8.4|Africa_Southern
+  - Africa_Western: GCAM 8.4|Africa_Western
+  - Argentina: GCAM 8.4|Argentina
+  - Australia_NZ: GCAM 8.4|Australia and New Zealand
+  - Brazil: GCAM 8.4|Brazil
+  - Canada: GCAM 8.4|Canada
+  - Central America and Caribbean: GCAM 8.4|Central America and Caribbean
+  - Central Asia: GCAM 8.4|Central Asia
+  - China: GCAM 8.4|China
+  - Colombia: GCAM 8.4|Colombia
+  - EU-12: GCAM 8.4|EU-12
+  - EU-15: GCAM 8.4|EU-15
+  - Ukraine: GCAM 8.4|Ukraine
+  - Europe_Non_EU: GCAM 8.4|Europe_Southeast
+  - European Free Trade Association: GCAM 8.4|European Free Trade Association
+  - India: GCAM 8.4|India
+  - Indonesia: GCAM 8.4|Indonesia
+  - Japan: GCAM 8.4|Japan
+  - Mexico: GCAM 8.4|Mexico
+  - Middle East: GCAM 8.4|Middle East
+  - Pakistan: GCAM 8.4|Pakistan
+  - Russia: GCAM 8.4|Russia
+  - South Africa: GCAM 8.4|South Africa
+  - South America_Northern: GCAM 8.4|South America_Northern
+  - South America_Southern: GCAM 8.4|South America_Southern
+  - South Asia: GCAM 8.4|South Asia
+  - South Korea: GCAM 8.4|South Korea
+  - Southeast Asia: GCAM 8.4|Southeast Asia
+  - Taiwan: GCAM 8.4|Taiwan
+  - USA: GCAM 8.4|USA
+  # G20 members (without renaming)
+  - Brazil
+  - Canada
+  - China
+  - India
+  - Japan
+  - South Korea
+
+common_regions:
+  - World:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Argentina
+      - Australia_NZ
+      - Brazil
+      - Canada
+      - Central America and Caribbean
+      - Central Asia
+      - China
+      - Colombia
+      - EU-12
+      - EU-15
+      - Ukraine
+      - Europe_Non_EU
+      - European Free Trade Association
+      - India
+      - Indonesia
+      - Japan
+      - Mexico
+      - Middle East
+      - Pakistan
+      - Russia
+      - South Africa
+      - South America_Northern
+      - South America_Southern
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+      - USA
+
+  # R5 regions
+  - Asia (R5):
+      - China
+      - India
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Latin America (R5):
+      - Brazil
+      - Central America and Caribbean
+      - Mexico
+      - South America_Northern
+      - South America_Southern
+      - Argentina
+      - Colombia
+  - Middle East & Africa (R5):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Middle East
+      - South Africa
+  - OECD & EU (R5):
+      - USA
+      - Australia_NZ
+      - Canada
+      - EU-12
+      - EU-15
+      - Europe_Non_EU
+      - European Free Trade Association
+      - Japan
+  - Reforming Economies (R5):
+      - Central Asia
+      - Ukraine
+      - Russia
+
+  # R9 regions
+  - European Union (R9):
+      - EU-12
+      - EU-15
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - Canada
+      - Japan
+      - Australia_NZ
+      - Europe_Non_EU
+      - European Free Trade Association
+  - China (R9):
+      - China
+  - India (R9):
+      - India
+  - Other Asia (R9):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Reforming Economies (R9):
+      - Russia
+      - Central Asia
+      - Ukraine
+  - Latin America (R9):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East & Africa (R9):
+      - Middle East
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+
+  # R10 regions
+  - Africa (R10):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+  - China+ (R10):
+      - China
+      - South Korea
+  - Europe (R10):
+      - EU-12
+      - EU-15
+      - Ukraine
+      - Europe_Non_EU
+      - European Free Trade Association
+  - India+ (R10):
+      - India
+  - Latin America (R10):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East (R10):
+      - Middle East
+  - North America (R10):
+      - Canada
+      - USA
+  - Pacific OECD (R10):
+      - Japan
+      - Australia_NZ
+  - Reforming Economies (R10):
+      - Russia
+      - Central Asia
+  - Rest of Asia (R10):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - Southeast Asia
+      - Taiwan
+
+  # G20 members (aggregation or renaming)
+  - United States:
+      - USA
+  - African Union:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+  - European Union and United Kingdom:
+      - EU-12
+      - EU-15

--- a/mappings/GCAM/GCAM_9.1.yaml
+++ b/mappings/GCAM/GCAM_9.1.yaml
@@ -1,0 +1,217 @@
+model:
+  - GCAM 9.1
+  - GCAM-CGS 9.1
+
+native_regions:
+  - Africa_Eastern: GCAM 9.1|Africa_Eastern
+  - Africa_Northern: GCAM 9.1|Africa_Northern
+  - Africa_Southern: GCAM 9.1|Africa_Southern
+  - Africa_Western: GCAM 9.1|Africa_Western
+  - Argentina: GCAM 9.1|Argentina
+  - Australia_NZ: GCAM 9.1|Australia and New Zealand
+  - Brazil: GCAM 9.1|Brazil
+  - Canada: GCAM 9.1|Canada
+  - Central America and Caribbean: GCAM 9.1|Central America and Caribbean
+  - Central Asia: GCAM 9.1|Central Asia
+  - China: GCAM 9.1|China
+  - Colombia: GCAM 9.1|Colombia
+  - EU-12: GCAM 9.1|EU-12
+  - EU-15: GCAM 9.1|EU-15
+  - Ukraine: GCAM 9.1|Ukraine
+  - Europe_Non_EU: GCAM 9.1|Europe_Southeast
+  - European Free Trade Association: GCAM 9.1|European Free Trade Association
+  - India: GCAM 9.1|India
+  - Indonesia: GCAM 9.1|Indonesia
+  - Japan: GCAM 9.1|Japan
+  - Mexico: GCAM 9.1|Mexico
+  - Middle East: GCAM 9.1|Middle East
+  - Pakistan: GCAM 9.1|Pakistan
+  - Russia: GCAM 9.1|Russia
+  - South Africa: GCAM 9.1|South Africa
+  - South America_Northern: GCAM 9.1|South America_Northern
+  - South America_Southern: GCAM 9.1|South America_Southern
+  - South Asia: GCAM 9.1|South Asia
+  - South Korea: GCAM 9.1|South Korea
+  - Southeast Asia: GCAM 9.1|Southeast Asia
+  - Taiwan: GCAM 9.1|Taiwan
+  - USA: GCAM 9.1|USA
+  # G20 members (without renaming)
+  - Brazil
+  - Canada
+  - China
+  - India
+  - Japan
+  - South Korea
+
+common_regions:
+  - World:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Argentina
+      - Australia_NZ
+      - Brazil
+      - Canada
+      - Central America and Caribbean
+      - Central Asia
+      - China
+      - Colombia
+      - EU-12
+      - EU-15
+      - Ukraine
+      - Europe_Non_EU
+      - European Free Trade Association
+      - India
+      - Indonesia
+      - Japan
+      - Mexico
+      - Middle East
+      - Pakistan
+      - Russia
+      - South Africa
+      - South America_Northern
+      - South America_Southern
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+      - USA
+
+  # R5 regions
+  - Asia (R5):
+      - China
+      - India
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Latin America (R5):
+      - Brazil
+      - Central America and Caribbean
+      - Mexico
+      - South America_Northern
+      - South America_Southern
+      - Argentina
+      - Colombia
+  - Middle East & Africa (R5):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - Middle East
+      - South Africa
+  - OECD & EU (R5):
+      - USA
+      - Australia_NZ
+      - Canada
+      - EU-12
+      - EU-15
+      - Europe_Non_EU
+      - European Free Trade Association
+      - Japan
+  - Reforming Economies (R5):
+      - Central Asia
+      - Ukraine
+      - Russia
+
+  # R9 regions
+  - European Union (R9):
+      - EU-12
+      - EU-15
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - Canada
+      - Japan
+      - Australia_NZ
+      - Europe_Non_EU
+      - European Free Trade Association
+  - China (R9):
+      - China
+  - India (R9):
+      - India
+  - Other Asia (R9):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - South Korea
+      - Southeast Asia
+      - Taiwan
+  - Reforming Economies (R9):
+      - Russia
+      - Central Asia
+      - Ukraine
+  - Latin America (R9):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East & Africa (R9):
+      - Middle East
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+
+  # R10 regions
+  - Africa (R10):
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+      - South Africa
+  - China+ (R10):
+      - China
+      - South Korea
+  - Europe (R10):
+      - EU-12
+      - EU-15
+      - Ukraine
+      - Europe_Non_EU
+      - European Free Trade Association
+  - India+ (R10):
+      - India
+  - Latin America (R10):
+      - Argentina
+      - South America_Northern
+      - South America_Southern
+      - Brazil
+      - Colombia
+      - Central America and Caribbean
+      - Mexico
+  - Middle East (R10):
+      - Middle East
+  - North America (R10):
+      - Canada
+      - USA
+  - Pacific OECD (R10):
+      - Japan
+      - Australia_NZ
+  - Reforming Economies (R10):
+      - Russia
+      - Central Asia
+  - Rest of Asia (R10):
+      - Indonesia
+      - Pakistan
+      - South Asia
+      - Southeast Asia
+      - Taiwan
+
+  # G20 members (aggregation or renaming)
+  - United States:
+      - USA
+  - African Union:
+      - Africa_Eastern
+      - Africa_Northern
+      - Africa_Southern
+      - Africa_Western
+  - European Union and United Kingdom:
+      - EU-12
+      - EU-15


### PR DESCRIPTION
Per request for the IAM-diagnostics exercise. Not that the mappings are done both for the PNNL and the CGS version of GCAM, but the region-names will always use the model-name-plus-version (but no institutional identifier).

FYI @melgeorgev @christophbertram @jayfuhrman @MarkMDekker 