### PR TITLE
Register EPPA 8

### DIFF
--- a/definitions/region/native_regions/EPPA_v8.yaml
+++ b/definitions/region/native_regions/EPPA_v8.yaml
@@ -1,8 +1,8 @@
 # The model documentation and regional aggregation for EPPA version 8 can be found
 # at https://www.scirp.org/journal/paperinformation?paperid=118216
 - EPPA 8:
-    - EPPA 8|USA:
-        countries: USA
+    - EPPA 8|United States:
+        countries: United States
     - EPPA 8|Canada:
         countries: Canada
     - EPPA 8|Mexico:
@@ -68,7 +68,7 @@
           Bangladesh, Brunei Darussalam, Cambodia, Laos, Sri Lanka, Mongolia, Nepal, Pakistan,
           Viet Nam, Macao, North Korea, Bhutan, Maldives, Myanmar, Timor-Leste
         ]
-    - EPPA 8|Korea:
+    - EPPA 8|South Korea:
         countries: South Korea
     - EPPA 8|Indonesia:
         countries: Indonesia

--- a/definitions/region/native_regions/EPPA_v8.yaml
+++ b/definitions/region/native_regions/EPPA_v8.yaml
@@ -11,21 +11,21 @@
         countries: Japan
     - EPPA 8|Australia and New Zealand:
         countries: [
-          Australia, New zealand
+          Australia, New Zealand
         ]
     - EPPA 8|Europe:
         countries: [
-          Austria, Belgium, Bulgaria, Switzerland, Cyprus, Czech Republic, Germany, Denmark, 
+          Austria, Belgium, Bulgaria, Switzerland, Cyprus, Czechia, Germany, Denmark,
           Spain, Estonia, Finland, France, United Kingdom, Greece, Croatia, Hungary,
           Ireland, Italy, Lithuania, Luxembourg, Latvia, Malta, Netherlands, Norway,
           Poland, Portugal, Romania, Slovakia, Slovenia, Sweden, Iceland, Liechtenstein
         ]
     - EPPA 8|Rest of Europe:
         countries: [
-          Albania, Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Turkey,
-          Ukraine, Republic of Moldova, Andorra, Bosnia and Herzegovina, Faroe Islands, Gibraltar, Guernsey, Holy See, 
-          Isle of Man, Jersey, Kosovo, Monaco, Montenegro, North Macedonia, San Marino, Sark, 
-          Turkmenistan
+          Albania, Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan,
+          Turkey, Ukraine, Moldova, Andorra, Bosnia and Herzegovina, Faroe Islands,
+          Gibraltar, Guernsey, Isle of Man, Jersey, Kosovo, Monaco, Montenegro,
+          North Macedonia, San Marino, Turkmenistan
         ]
     - EPPA 8|Russia:
         countries: Russian Federation
@@ -43,32 +43,32 @@
         countries: Brazil
     - EPPA 8|Africa:
         countries: [
-          Benin, Burkina Faso, Botswana, Cote d'Ivoire, Cameroon, Egypt, Ethiopia, Ghana,
-          Guinea, Kenya, Morocco, Madagascar, Mozambique, Mauritius, Malawi, Namibia, 
-          Nigeria, Rwanda, Senegal, Togo, Tunisia, Tanzania United Republic of, Uganda, South Central Africa,
-          Central Africa, Djibouti, Eritrea, Mayotte, Seychelles, Somalia, South Sudan, Libya, 
-          Western Sahara, Lesotho, Cabo Verde, Gambia, Guinea-Bissau, Liberia, Saint Helena, Sierra Leone, 
+          Benin, Burkina Faso, Botswana, Côte d'Ivoire, Cameroon, Egypt, Ethiopia,
+          Ghana, Guinea, Kenya, Morocco, Madagascar, Mozambique, Mauritius, Malawi,
+          Namibia, Nigeria, Rwanda, Senegal, Togo, Tunisia, Tanzania, Uganda, Djibouti,
+          Eritrea, Mayotte, Seychelles, Somalia, South Sudan, Libya, Western Sahara,
+          Lesotho, Cabo Verde, Gambia, Guinea-Bissau, Liberia, Sierra Leone,
           South Africa, Zambia, Zimbabwe
         ]
     - EPPA 8|Middle East:
         countries: [
-          United Arab Emirates, Bahrain, Iran Islamic Republic of, Israel, Jordan, Kuwait, Oman, Qatar,
+          United Arab Emirates, Bahrain, Iran, Israel, Jordan, Kuwait, Oman, Qatar,
           Saudi Arabia, Yemen
         ]
     - EPPA 8|Latin America:
         countries: [
-          Argentina, Plurinational Republic of Bolivia, Chile, Colombia, Costa Rica, Dominican Republic, Ecuador, Guatemala,
-          Honduras, Jamaica, Nicaragua, Panama, Peru, Puerto Rico, Paraguay, El Salvador,
-          Trinidad and Tobago, Uruguay, Venezuela, Belize, Caribbean, Bermuda, Greenland, Saint Pierre and Miquelon, 
-          Falkland Islands (Malvinas), French Guiana, Guyana, South Georgia and the South Sandwich Islands, Suriname
+          Argentina, Bolivia, Chile, Colombia, Costa Rica, Dominican Republic, Ecuador,
+          Guatemala, Honduras, Jamaica, Nicaragua, Panama, Peru, Puerto Rico, Paraguay,
+          El Salvador, Trinidad and Tobago, Uruguay, Venezuela, Belize, Bermuda,
+          Greenland, Saint Pierre and Miquelon, Falkland Islands (Malvinas),
+          French Guiana, Guyana, South Georgia and the South Sandwich Islands, Suriname
         ]
     - EPPA 8|Rest of Asia:
         countries: [
-          Bangladesh, Brunei, Cambodia, Lao People's Democratic Republic, Sri Lanka, Mongolia, Nepal, Pakistan,
-          Viet Nam, Macao Special Administrative Region of China, Democratic People's Republic of Korea, Bhutan, Maldives, Myanmar, Timor-Leste
+          Bangladesh, Brunei Darussalam, Cambodia, Laos, Sri Lanka, Mongolia, Nepal, Pakistan,
+          Viet Nam, Macao, North Korea, Bhutan, Maldives, Myanmar, Timor-Leste
         ]
     - EPPA 8|Korea:
         countries: South Korea
     - EPPA 8|Indonesia:
         countries: Indonesia
-

--- a/definitions/region/native_regions/EPPA_v8.yaml
+++ b/definitions/region/native_regions/EPPA_v8.yaml
@@ -1,0 +1,74 @@
+# The model documentation and regional aggregation for EPPA version 8 can be found
+# at https://www.scirp.org/journal/paperinformation?paperid=118216
+- EPPA 8:
+    - EPPA 8|USA:
+        countries: USA
+    - EPPA 8|Canada:
+        countries: Canada
+    - EPPA 8|Mexico:
+        countries: Mexico
+    - EPPA 8|Japan:
+        countries: Japan
+    - EPPA 8|Australia and New Zealand:
+        countries: [
+          Australia, New zealand
+        ]
+    - EPPA 8|Europe:
+        countries: [
+          Austria, Belgium, Bulgaria, Switzerland, Cyprus, Czech Republic, Germany, Denmark, 
+          Spain, Estonia, Finland, France, United Kingdom, Greece, Croatia, Hungary,
+          Ireland, Italy, Lithuania, Luxembourg, Latvia, Malta, Netherlands, Norway,
+          Poland, Portugal, Romania, Slovakia, Slovenia, Sweden, Iceland, Liechtenstein
+        ]
+    - EPPA 8|Rest of Europe:
+        countries: [
+          Albania, Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan, Turkey,
+          Ukraine, Republic of Moldova, Andorra, Bosnia and Herzegovina, Faroe Islands, Gibraltar, Guernsey, Holy See, 
+          Isle of Man, Jersey, Kosovo, Monaco, Montenegro, North Macedonia, San Marino, Sark, 
+          Turkmenistan
+        ]
+    - EPPA 8|Russia:
+        countries: Russian Federation
+    - EPPA 8|East Asia:
+        countries: [
+          Malaysia, Philippines, Singapore, Taiwan, Thailand
+        ]
+    - EPPA 8|China:
+        countries: [
+          China, Hong Kong
+        ]
+    - EPPA 8|India:
+        countries: India
+    - EPPA 8|Brazil:
+        countries: Brazil
+    - EPPA 8|Africa:
+        countries: [
+          Benin, Burkina Faso, Botswana, Cote d'Ivoire, Cameroon, Egypt, Ethiopia, Ghana,
+          Guinea, Kenya, Morocco, Madagascar, Mozambique, Mauritius, Malawi, Namibia, 
+          Nigeria, Rwanda, Senegal, Togo, Tunisia, Tanzania United Republic of, Uganda, South Central Africa,
+          Central Africa, Djibouti, Eritrea, Mayotte, Seychelles, Somalia, South Sudan, Libya, 
+          Western Sahara, Lesotho, Cabo Verde, Gambia, Guinea-Bissau, Liberia, Saint Helena, Sierra Leone, 
+          South Africa, Zambia, Zimbabwe
+        ]
+    - EPPA 8|Middle East:
+        countries: [
+          United Arab Emirates, Bahrain, Iran Islamic Republic of, Israel, Jordan, Kuwait, Oman, Qatar,
+          Saudi Arabia, Yemen
+        ]
+    - EPPA 8|Latin America:
+        countries: [
+          Argentina, Plurinational Republic of Bolivia, Chile, Colombia, Costa Rica, Dominican Republic, Ecuador, Guatemala,
+          Honduras, Jamaica, Nicaragua, Panama, Peru, Puerto Rico, Paraguay, El Salvador,
+          Trinidad and Tobago, Uruguay, Venezuela, Belize, Caribbean, Bermuda, Greenland, Saint Pierre and Miquelon, 
+          Falkland Islands (Malvinas), French Guiana, Guyana, South Georgia and the South Sandwich Islands, Suriname
+        ]
+    - EPPA 8|Rest of Asia:
+        countries: [
+          Bangladesh, Brunei, Cambodia, Lao People's Democratic Republic, Sri Lanka, Mongolia, Nepal, Pakistan,
+          Viet Nam, Macao Special Administrative Region of China, Democratic People's Republic of Korea, Bhutan, Maldives, Myanmar, Timor-Leste
+        ]
+    - EPPA 8|Korea:
+        countries: South Korea
+    - EPPA 8|Indonesia:
+        countries: Indonesia
+

--- a/mappings/EPPA_v8.yaml
+++ b/mappings/EPPA_v8.yaml
@@ -1,0 +1,146 @@
+model:
+  - EPPA 8
+
+native_regions:
+  - USA: EPPA 8|United States
+  - CAN: EPPA 8|Canada
+  - MEX: EPPA 8|Mexico
+  - JPN: EPPA 8|Japan
+  - ANZ: EPPA 8|Australia - New Zealand
+  - EUR: EPPA 8|Europe
+  - ROE: EPPA 8|Rest of Europe
+  - RUS: EPPA 8|Russia
+  - ASI: EPPA 8|East Asia
+  - CHN: EPPA 8|China
+  - IND: EPPA 8|India
+  - BRA: EPPA 8|Brazil
+  - AFR: EPPA 8|Africa
+  - MES: EPPA 8|Middle East
+  - LAM: EPPA 8|Latin America
+  - REA: EPPA 8|Rest of Asia
+  - KOR: EPPA 8|South Korea
+  - IDZ: EPPA 8|Indonesia
+
+common_regions:
+  - World:
+      - USA	
+      - CAN	
+      - MEX	
+      - JPN	
+      - ANZ	
+      - EUR	
+      - ROE	
+      - RUS	
+      - ASI	
+      - CHN	
+      - IND	
+      - BRA	
+      - AFR	
+      - MES	
+      - LAM	
+      - REA	
+      - KOR	
+      - IDZ	
+
+  # R5 regions
+  - OECD & EU (R5):
+      - USA
+      - CAN
+      - EUR
+      - JPN
+      - ANZ
+  - Reforming Economies (R5):
+      - RUS
+      - ROE
+  - Asia (R5):
+      - JPN
+      - ASI
+      - IND
+      - IDZ
+      - KOR
+      - REA
+      - CHN
+  - Middle East & Africa (R5):
+      - MES
+      - AFR
+  - Latin America (R5):
+      - BRA
+      - LAM
+
+  # R9 regions
+  - European Union (R9):
+      - EUR
+
+  - USA (R9):
+      - USA
+  - Other OECD (R9):
+      - CAN
+      - JPN
+      - ANZ
+  - China (R9):
+      - CHN
+  - India (R9):
+      - IND
+  - Other Asia (R9):
+      - ASI
+      - IDZ
+      - KOR
+      - REA
+  - Reforming Economies (R9):
+      - RUS
+      - ROE
+  - Latin America (R9):
+      - BRA
+      - MEX
+      - LAM
+  - Middle East & Africa (R9):
+      - MES
+      - AFR
+
+  # R10 regions
+  - Africa (R10):
+      - AFR
+  - China+ (R10):
+      - CHN
+      - KOR
+  - Europe (R10):
+      - EUR
+      - ROE
+  - India+ (R10):
+      - IND
+  - Latin America (R10):
+      - MEX
+      - LAM
+      - BRA
+  - Middle East (R10):
+      - MES
+  - North America (R10):
+      - USA
+      - CAN
+  - Pacific OECD (R10):
+      - JPN
+      - ANZ
+  - Reforming Economies (R10):
+      - RUS
+      - ROE
+  - Rest of Asia (R10):
+      - ASI
+      - REA
+
+  # mapping for G20 members
+  - Brazil:
+      - BRA
+  - Canada:
+      - CAN
+  - China:
+      - CHN
+  - India:
+      - IND
+  - Japan:
+      - JPN
+  - South Korea:
+      - KOR
+  - United States:
+      - USA
+  - African Union:
+      - AFR

--- a/mappings/EPPA_v8.yaml
+++ b/mappings/EPPA_v8.yaml
@@ -6,7 +6,7 @@ native_regions:
   - CAN: EPPA 8|Canada
   - MEX: EPPA 8|Mexico
   - JPN: EPPA 8|Japan
-  - ANZ: EPPA 8|Australia - New Zealand
+  - ANZ: EPPA 8|Australia and New Zealand
   - EUR: EPPA 8|Europe
   - ROE: EPPA 8|Rest of Europe
   - RUS: EPPA 8|Russia

--- a/mappings/EPPA_v8.yaml
+++ b/mappings/EPPA_v8.yaml
@@ -23,24 +23,24 @@ native_regions:
 
 common_regions:
   - World:
-      - USA	
-      - CAN	
-      - MEX	
-      - JPN	
-      - ANZ	
-      - EUR	
-      - ROE	
-      - RUS	
-      - ASI	
-      - CHN	
-      - IND	
-      - BRA	
-      - AFR	
-      - MES	
-      - LAM	
-      - REA	
-      - KOR	
-      - IDZ	
+      - USA
+      - CAN
+      - MEX
+      - JPN
+      - ANZ
+      - EUR
+      - ROE
+      - RUS
+      - ASI
+      - CHN
+      - IND
+      - BRA
+      - AFR
+      - MES
+      - LAM
+      - REA
+      - KOR
+      - IDZ
 
   # R5 regions
   - OECD & EU (R5):


### PR DESCRIPTION
FYI @chenyhmitedu

I transferred the definition and mapping file from https://github.com/chenyhmitedu/EPPA and made the following changes:
- Harmonise country names with nomenclature country names (see https://docs.ece.iiasa.ac.at/standards/countries.html)
- Remove aggregates like "South Central Africa" - please provide country explicit names (or we merge as is)
- Harmonise region-display region names between definitions and mapping
- Apply formatting (remove tabtops and enforce line breaks)

You can look at the individual commits for the detailed changes.