### PR TITLE
Register GEMINI v7.3

### DIFF
--- a/definitions/region/native_regions/GEMINI_v7.3.yaml
+++ b/definitions/region/native_regions/GEMINI_v7.3.yaml
@@ -1,0 +1,169 @@
+- GEMINI 7.3:
+  - GEMINI 7.3|ASI:
+      countries:
+      - Australia
+      - New Zealand
+      - Rest of Oceania
+      - Japan
+      - Korea
+      - Mongolia
+      - Taiwan Province of China
+      - Rest of East Asia
+      - Brunei Darussalam
+      - Cambodia
+      - Indonesia
+      - Laos
+      - Malaysia
+      - Philippines
+      - Singapore
+      - Thailand
+      - Viet Nam
+      - Nepal
+      - Pakistan
+      - Sri Lanka
+  - GEMINI 7.3|CHI:
+      countries:
+      - China
+      - Hong Kong
+  - GEMINI 7.3|ROW:
+      countries:
+      - Afghanistan
+      - Bangladesh
+      - Canada
+      - United Kingdom
+      - Switzerland
+      - Norway
+      - Rest of EFTA
+      - Albania
+      - Serbia
+      - Belarus
+      - Ukraine
+      - Kazakhstan
+      - Kyrgyzstan
+      - Tajikistan
+      - Uzbekistan
+      - Armenia
+      - Azerbaijan
+      - Georgia
+      - Israel
+      - T rkiye
+  - GEMINI 7.3|IND:
+      countries:
+      - India
+  - GEMINI 7.3|USA:
+      countries:
+      - United States of America
+  - GEMINI 7.3|CSA:
+      countries:
+      - Mexico
+      - Argentina
+      - Bolivia
+      - Brazil
+      - Chile
+      - Colombia
+      - Ecuador
+      - Paraguay
+      - Peru
+      - Uruguay
+      - Venezuela
+      - Costa Rica
+      - Guatemala
+      - Honduras
+      - Nicaragua
+      - Panama
+      - El Salvador
+      - Dominican Republic
+      - Haiti
+      - Jamaica
+      - Puerto Rico
+      - Trinidad and Tobago
+      - Caribbean
+  - GEMINI 7.3|EU27:
+      countries:
+      - Austria
+      - Belgium
+      - Bulgaria
+      - Croatia
+      - Cyprus
+      - Czechia
+      - Denmark
+      - Estonia
+      - Finland
+      - France
+      - Germany
+      - Greece
+      - Hungary
+      - Ireland
+      - Italy
+      - Latvia
+      - Lithuania
+      - Luxembourg
+      - Malta
+      - Netherlands
+      - Poland
+      - Portugal
+      - Romania
+      - Slovakia
+      - Slovenia
+      - Spain
+      - Sweden
+  - GEMINI 7.3|RUS:
+      countries:
+      - Russian Federation
+  - GEMINI 7.3|MID:
+      countries:
+      - Bahrain
+      - Iran (Islamic Republic of)
+      - Iraq
+      - Jordan
+      - Kuwait
+      - Lebanon
+      - Oman
+      - Palestine
+      - Qatar
+      - Saudi Arabia
+      - Syrian Arab Republic
+      - United Arab Emirates
+  - GEMINI 7.3|AFR:
+      countries:
+      - Algeria
+      - Egypt
+      - Morocco
+      - Tunisia
+      - Benin
+      - Burkina Faso
+      - Cameroon
+      - C te d'Ivoire
+      - Ghana
+      - Guinea
+      - Mali
+      - Niger
+      - Nigeria
+      - Senegal
+      - Togo
+      - Central African Republic
+      - Chad
+      - Congo
+      - Democratic Republic of the Con
+      - Equatorial Guinea
+      - Gabon
+      - South-Central Africa
+      - Comoros
+      - Ethiopia
+      - Kenya
+      - Madagascar
+      - Malawi
+      - Mauritius
+      - Mozambique
+      - Rwanda
+      - Sudan
+      - United Republic of Tanzania
+      - Uganda
+      - Zambia
+      - Zimbabwe
+      - Rest of Eastern Africa
+      - Botswana
+      - Eswatini
+      - Namibia
+      - South Africa
+      - Rest of Southern African Custo

--- a/definitions/region/native_regions/GEMINI_v7.3.yaml
+++ b/definitions/region/native_regions/GEMINI_v7.3.yaml
@@ -3,12 +3,10 @@
       countries:
       - Australia
       - New Zealand
-      - Rest of Oceania
       - Japan
-      - Korea
+      - South Korea
       - Mongolia
-      - Taiwan Province of China
-      - Rest of East Asia
+      - Taiwan
       - Brunei Darussalam
       - Cambodia
       - Indonesia
@@ -33,7 +31,6 @@
       - United Kingdom
       - Switzerland
       - Norway
-      - Rest of EFTA
       - Albania
       - Serbia
       - Belarus
@@ -46,13 +43,13 @@
       - Azerbaijan
       - Georgia
       - Israel
-      - T rkiye
+      - Turkey
   - GEMINI 7.3|IND:
       countries:
       - India
   - GEMINI 7.3|USA:
       countries:
-      - United States of America
+      - United States
   - GEMINI 7.3|CSA:
       countries:
       - Mexico
@@ -77,7 +74,6 @@
       - Jamaica
       - Puerto Rico
       - Trinidad and Tobago
-      - Caribbean
   - GEMINI 7.3|EU27:
       countries:
       - Austria
@@ -113,7 +109,7 @@
   - GEMINI 7.3|MID:
       countries:
       - Bahrain
-      - Iran (Islamic Republic of)
+      - Iran
       - Iraq
       - Jordan
       - Kuwait
@@ -122,7 +118,7 @@
       - Palestine
       - Qatar
       - Saudi Arabia
-      - Syrian Arab Republic
+      - Syria
       - United Arab Emirates
   - GEMINI 7.3|AFR:
       countries:
@@ -133,7 +129,7 @@
       - Benin
       - Burkina Faso
       - Cameroon
-      - C te d'Ivoire
+      - Côte d'Ivoire
       - Ghana
       - Guinea
       - Mali
@@ -144,10 +140,9 @@
       - Central African Republic
       - Chad
       - Congo
-      - Democratic Republic of the Con
+      - Democratic Republic of the Congo
       - Equatorial Guinea
       - Gabon
-      - South-Central Africa
       - Comoros
       - Ethiopia
       - Kenya
@@ -157,13 +152,11 @@
       - Mozambique
       - Rwanda
       - Sudan
-      - United Republic of Tanzania
+      - Tanzania
       - Uganda
       - Zambia
       - Zimbabwe
-      - Rest of Eastern Africa
       - Botswana
       - Eswatini
       - Namibia
       - South Africa
-      - Rest of Southern African Custo

--- a/mappings/GEMINI_v7.3.yaml
+++ b/mappings/GEMINI_v7.3.yaml
@@ -1,0 +1,89 @@
+model:
+- GEMINI 7.3
+native_regions:
+- ASI: GEMINI 7.3|ASI
+- CHI: GEMINI 7.3|CHI
+- ROW: GEMINI 7.3|ROW
+- IND: GEMINI 7.3|IND
+- USA: GEMINI 7.3|USA
+- CSA: GEMINI 7.3|CSA
+- EU27: GEMINI 7.3|EU27
+- RUS: GEMINI 7.3|RUS
+- MID: GEMINI 7.3|MID
+- AFR: GEMINI 7.3|AFR
+common_regions:
+- World:
+  - ASI
+  - CHI
+  - ROW
+  - IND
+  - USA
+  - CSA
+  - EU27
+  - RUS
+  - MID
+  - AFR
+
+  # R5 regions
+- OECD & EU (R5):
+  - EU27
+  - USA
+- Reforming Economies (R5):
+  - RUS
+- Asia (R5):
+  - CHI
+  - IND
+  - ASI
+- Middle East & Africa (R5):
+  - MID
+  - AFR
+- Latin America (R5):
+  - CSA
+
+  # R9 regions
+- European Union (R9):
+  - EU27
+- USA (R9):
+  - USA
+- China (R9):
+  - CHI
+- India (R9):
+  - IND
+- Other Asia (R9):
+  - ASI
+- Reforming Economies (R9):
+  - RUS
+- Latin America (R9):
+  - CSA
+- Middle East & Africa (R9):
+  - MID
+  - AFR
+
+
+  # R10 regions
+- Africa (R10):
+  - AFR
+- China+ (R10):
+  - CHI
+- India+ (R10):
+  - IND
+- Latin America (R10):
+  - CSA
+- Middle East (R10):
+  - MID
+- North America (R10):
+  - USA
+- Reforming Economies (R10):
+  - RUS
+
+# mapping for G20 members
+- China:
+  - CHI
+- India:
+  - IND
+- United States:
+  - USA
+- European Union:
+  - EU27
+- African Union:
+  - AFR


### PR DESCRIPTION
Adding the model registration files for GEMINI 7.3 received via email - please take a look @mvielle 

The second commit implemented hHarmonise country names with nomenclature country names (see https://docs.ece.iiasa.ac.at/standards/countries.html)

Also, using aggregates in the `countries` (e.g., "Rest of East Asia" or "Caribbean") is not allo

It would also be helpful to replace the abbreviations in the native-region-names (as used in the Scenario Explorer) like `GEMINI 7.3|ASI` with more intuitive and readable names, e.g. `GEMINI 7.3|Asia`. Any objections?

FYI @MathijsHarmsenPBL 